### PR TITLE
fix: trust and polish — 404, error boundary, favicon, legal pages, bug fixes

### DIFF
--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs><linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" style="stop-color:#6366f1"/><stop offset="100%" style="stop-color:#4f46e5"/></linearGradient></defs>
+  <rect width="32" height="32" rx="8" fill="url(#g)"/>
+  <text x="16" y="24" font-size="22" font-family="system-ui,sans-serif" font-weight="700" fill="white" text-anchor="middle">G</text>
+</svg>

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-give-bg px-6">
+      <div className="text-center max-w-md">
+        <p className="text-5xl">😵</p>
+        <h1 className="mt-4 text-3xl font-bold text-gray-900">
+          Something went wrong
+        </h1>
+        <p className="mt-4 text-gray-600 leading-relaxed">
+          We hit an unexpected error. This has been noted and we&apos;ll look
+          into it.
+        </p>
+        <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <button
+            onClick={reset}
+            className="text-sm font-semibold text-white bg-give-primary hover:bg-give-primary-dark transition-colors px-6 py-3 rounded-lg"
+          >
+            Try Again
+          </button>
+          <a
+            href="/"
+            className="text-sm font-semibold text-give-primary hover:text-give-primary-dark transition-colors px-6 py-3"
+          >
+            Back to Home
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -9,6 +9,9 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
+  icons: {
+    icon: "/favicon.svg",
+  },
   title: "Give — Fundraising That's Fair",
   description:
     "Transparent nonprofit fundraising with 1% fees. No hidden donor tips, no gotchas. Donation forms, CRM, events, peer-to-peer, and automatic payouts — everything your nonprofit needs.",

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-give-bg px-6">
+      <div className="text-center max-w-md">
+        <p className="text-7xl font-extrabold text-give-primary">404</p>
+        <h1 className="mt-4 text-3xl font-bold text-gray-900">
+          Page not found
+        </h1>
+        <p className="mt-4 text-gray-600 leading-relaxed">
+          Sorry, we couldn&apos;t find what you were looking for. It might have
+          been moved or no longer exists.
+        </p>
+        <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <Link
+            href="/"
+            className="text-sm font-semibold text-white bg-give-primary hover:bg-give-primary-dark transition-colors px-6 py-3 rounded-lg"
+          >
+            Back to Home
+          </Link>
+          <Link
+            href="/dashboard"
+            className="text-sm font-semibold text-give-primary hover:text-give-primary-dark transition-colors px-6 py-3"
+          >
+            Go to Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -48,7 +48,7 @@ const COMPARISON = [
   {
     name: "Zeffy",
     highlight: false,
-    fee: '0%"',
+    fee: '0%',
     feeNote: "but...",
     donorTips: "17% default tip",
     monthlyFee: "$0",
@@ -99,7 +99,7 @@ export default function HomePage() {
           </div>
           <div className="flex items-center gap-3">
             <Link
-              href="/dashboard"
+              href="/sign-in"
               className="text-sm font-medium text-gray-600 hover:text-give-primary transition-colors px-4 py-2"
             >
               Log In
@@ -462,6 +462,12 @@ export default function HomePage() {
               <a href="#compare" className="hover:text-white transition-colors">
                 Compare
               </a>
+              <Link href="/privacy" className="hover:text-white transition-colors">
+                Privacy
+              </Link>
+              <Link href="/terms" className="hover:text-white transition-colors">
+                Terms
+              </Link>
             </div>
             <div className="text-sm">
               &copy; {new Date().getFullYear()} Give. Fundraising that&apos;s fair.

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,103 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Privacy Policy — Give",
+};
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-give-bg">
+      <nav className="border-b border-gray-200 bg-white/80 backdrop-blur-sm">
+        <div className="max-w-4xl mx-auto px-6 py-4">
+          <Link href="/" className="text-xl font-bold text-give-primary">
+            Give
+          </Link>
+        </div>
+      </nav>
+      <main className="max-w-4xl mx-auto px-6 py-16">
+        <h1 className="text-4xl font-extrabold text-gray-900">Privacy Policy</h1>
+        <p className="mt-2 text-sm text-gray-500">Last updated: March 1, 2026</p>
+
+        <div className="mt-10 prose prose-gray max-w-none space-y-8">
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">1. Information We Collect</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              We collect information you provide directly: name, email, organization details when you
+              create an account, and payment information processed securely through Stripe. For donors,
+              we collect name, email, and payment details necessary to process donations.
+            </p>
+            <p className="mt-2 text-gray-600 leading-relaxed">
+              We automatically collect usage data including IP address, browser type, pages visited,
+              and interaction patterns to improve our service.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">2. How We Use Your Information</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              We use your information to: process donations and payouts, manage your account,
+              send transaction receipts and notifications, improve our platform, comply with legal
+              obligations, and prevent fraud.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">3. Payment Processing</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              All payment processing is handled by Stripe. We never store credit card numbers on our
+              servers. Stripe&apos;s privacy policy and PCI-DSS compliance govern payment data handling.
+              Give charges a transparent 1% (Basic) or 2% (Pro) platform fee — no hidden charges to donors.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">4. Data Sharing</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              We share donor information with the nonprofit organization receiving the donation so
+              they can acknowledge gifts and maintain donor relationships. We do not sell personal
+              data to third parties. We may share data with service providers (Stripe, hosting,
+              email) who process it on our behalf under strict agreements.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">5. Data Security</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              We use industry-standard encryption (TLS/SSL) for data in transit and at rest.
+              Access to personal data is restricted to authorized personnel. We conduct regular
+              security reviews and maintain incident response procedures.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">6. Your Rights</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              You may request access to, correction of, or deletion of your personal data at any time
+              by contacting us. California residents have additional rights under the CCPA. We honor
+              Do Not Track signals.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">7. Cookies</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              We use essential cookies for authentication and session management. We use analytics
+              cookies to understand how our platform is used. You can disable non-essential cookies
+              in your browser settings.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">8. Contact</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              For privacy questions or data requests, contact us at{" "}
+              <a href="mailto:privacy@givefundraising.com" className="text-give-primary hover:underline">
+                privacy@givefundraising.com
+              </a>.
+            </p>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,0 +1,119 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Terms of Service — Give",
+};
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-give-bg">
+      <nav className="border-b border-gray-200 bg-white/80 backdrop-blur-sm">
+        <div className="max-w-4xl mx-auto px-6 py-4">
+          <Link href="/" className="text-xl font-bold text-give-primary">
+            Give
+          </Link>
+        </div>
+      </nav>
+      <main className="max-w-4xl mx-auto px-6 py-16">
+        <h1 className="text-4xl font-extrabold text-gray-900">Terms of Service</h1>
+        <p className="mt-2 text-sm text-gray-500">Last updated: March 1, 2026</p>
+
+        <div className="mt-10 prose prose-gray max-w-none space-y-8">
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">1. Acceptance of Terms</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              By accessing or using Give (&quot;the Platform&quot;), operated by Datawake LLC, you agree
+              to these Terms of Service. If you are accepting on behalf of an organization, you
+              represent that you have authority to bind that organization.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">2. Platform Description</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              Give is a fundraising platform that enables 501(c)(3) nonprofit organizations to accept
+              donations online. We provide donation forms, donor management, campaign tools, and
+              automated payouts via Stripe Connect.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">3. Fees & Pricing</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              Give charges a transparent platform fee of 1% (Basic tier) or 2% (Pro tier) on each
+              donation. Payment processing fees (approximately 2.2% + $0.30 for cards, 0.8% capped
+              at $5 for ACH) are charged by Stripe and passed through to the organization. There are
+              no monthly fees, no setup fees, and no hidden charges. Donors are never asked to pay
+              tips or platform fees.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">4. Organization Responsibilities</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              Organizations must: maintain valid 501(c)(3) status (or equivalent tax-exempt status),
+              use donated funds for their stated charitable purposes, comply with all applicable laws
+              including state charitable solicitation requirements, provide accurate organization
+              information, and respond to donor inquiries in a timely manner.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">5. Donor Rights</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              Donors have the right to: know exactly what fees are charged, receive tax-deductible
+              receipts for eligible donations, request refunds within 90 days (subject to organization
+              approval), and have their personal data handled per our Privacy Policy.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">6. Prohibited Use</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              You may not use Give for: fraudulent fundraising, money laundering, personal (non-charitable)
+              fundraising, any activity that violates applicable laws, or to process payments for goods
+              or services (Give is for charitable donations only).
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">7. Payouts</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              Donations are paid out to organizations on a daily or weekly schedule via Stripe Connect.
+              Give deducts the platform fee before payout. Stripe deducts processing fees separately.
+              Payout timing depends on Stripe&apos;s standard schedule and your account verification status.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">8. Limitation of Liability</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              Give is provided &quot;as is&quot; without warranties of any kind. Datawake LLC&apos;s total
+              liability shall not exceed the platform fees paid by you in the 12 months preceding the claim.
+              We are not liable for actions of organizations or donors using the platform.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">9. Termination</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              Either party may terminate at any time. Upon termination, we will process any pending
+              payouts and provide a reasonable period to transition. We reserve the right to suspend
+              accounts that violate these terms.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold text-gray-900">10. Contact</h2>
+            <p className="mt-3 text-gray-600 leading-relaxed">
+              Questions about these terms? Contact us at{" "}
+              <a href="mailto:legal@givefundraising.com" className="text-give-primary hover:underline">
+                legal@givefundraising.com
+              </a>.
+            </p>
+          </section>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **#25**: Fixed stray quote in Zeffy comparison table (`0%"` → `0%`)
- **#26**: Fixed Login nav link (`/dashboard` → `/sign-in`)
- **#27**: Added custom 404 page + global error boundary
- Added SVG favicon to `/favicon.svg`
- **#22**: Added Privacy Policy (`/privacy`) and Terms of Service (`/terms`) pages
- Added Privacy/Terms links to footer

## Test Plan
- Visit `/nonexistent-page` → should see branded 404
- Click "Log In" in nav → should go to `/sign-in`
- Check Zeffy row in comparison table → `0%` (no stray quote)
- Visit `/privacy` and `/terms` → should render legal pages
- Check footer → Privacy and Terms links present
- Check browser tab → favicon visible

Closes #22, #25, #26, #27