### PR TITLE
feat: mobile navigation drawer for dashboard (issue #60)

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,53 +1,4 @@
-import Link from "next/link";
-
-const NAV_ITEMS = [
-  {
-    label: "Overview",
-    href: "/dashboard",
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
-      </svg>
-    ),
-  },
-  {
-    label: "Campaigns",
-    href: "/dashboard/campaigns",
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
-      </svg>
-    ),
-  },
-  {
-    label: "Donors",
-    href: "/dashboard/donors",
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z" />
-      </svg>
-    ),
-  },
-  {
-    label: "Donations",
-    href: "/dashboard/donations",
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
-      </svg>
-    ),
-  },
-  {
-    label: "Settings",
-    href: "/dashboard/settings",
-    icon: (
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-      </svg>
-    ),
-  },
-];
+import { DashboardSidebarProvider, MobileMenuButton } from "@/components/DashboardSidebar";
 
 export default function DashboardLayout({
   children,
@@ -55,70 +6,36 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-gray-50 flex">
-      {/* ── Sidebar ────────────────────────────────────── */}
-      <aside className="hidden md:flex flex-col w-64 bg-white border-r border-gray-100 fixed inset-y-0 left-0 z-30">
-        {/* Logo */}
-        <div className="px-6 py-5 border-b border-gray-100">
-          <Link
-            href="/"
-            className="text-xl font-bold text-give-primary tracking-tight"
-          >
-            Give
-          </Link>
-        </div>
-
-        {/* Navigation */}
-        <nav className="flex-1 px-3 py-4 space-y-1 overflow-y-auto">
-          {NAV_ITEMS.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-50 hover:text-give-primary transition-colors"
-            >
-              <span className="text-gray-400">{item.icon}</span>
-              {item.label}
-            </Link>
-          ))}
-        </nav>
-
-        {/* Sidebar footer */}
-        <div className="px-6 py-4 border-t border-gray-100">
-          <div className="flex items-center gap-3">
-            <div className="w-8 h-8 rounded-full bg-give-primary/10 flex items-center justify-center text-xs font-bold text-give-primary">
-              A
-            </div>
-            <div className="min-w-0">
-              <div className="text-sm font-medium text-gray-900 truncate">
-                My Nonprofit
-              </div>
-              <div className="text-xs text-gray-400 truncate">Basic plan</div>
-            </div>
-          </div>
-        </div>
-      </aside>
-
-      {/* ── Main Content ───────────────────────────────── */}
-      <div className="flex-1 md:ml-64">
+    <DashboardSidebarProvider>
+      {/* ── Main Content ─────────────────────────────── */}
+      <div className="flex-1 md:ml-64 min-w-0">
         {/* Top Bar */}
         <header className="bg-white border-b border-gray-100 sticky top-0 z-20">
-          <div className="px-6 py-4 flex items-center justify-between">
-            {/* Mobile menu button */}
-            <button className="md:hidden text-gray-500" aria-label="Open menu">
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-              </svg>
-            </button>
+          <div className="px-4 md:px-6 py-4 flex items-center gap-3">
+            {/* Hamburger — only visible on mobile, wired to the sidebar drawer */}
+            <MobileMenuButton />
 
-            <div className="hidden md:block">
+            {/* Org name — visible on desktop */}
+            <div className="flex-1 hidden md:block">
               <h2 className="text-sm font-medium text-gray-500">My Nonprofit</h2>
             </div>
 
+            {/* Push right-side icons to the end on mobile */}
+            <div className="flex-1 md:hidden" />
+
             <div className="flex items-center gap-4">
               {/* Notifications placeholder */}
-              <button className="text-gray-400 hover:text-gray-600 transition-colors" aria-label="Notifications">
+              <button
+                className="text-gray-400 hover:text-gray-600 transition-colors"
+                aria-label="Notifications"
+              >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0" />
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M14.857 17.082a23.848 23.848 0 005.454-1.31A8.967 8.967 0 0118 9.75v-.7V9A6 6 0 006 9v.75a8.967 8.967 0 01-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 01-5.714 0m5.714 0a3 3 0 11-5.714 0"
+                  />
                 </svg>
               </button>
 
@@ -131,8 +48,8 @@ export default function DashboardLayout({
         </header>
 
         {/* Page Content */}
-        <main className="p-6">{children}</main>
+        <main className="p-4 md:p-6">{children}</main>
       </div>
-    </div>
+    </DashboardSidebarProvider>
   );
 }

--- a/apps/web/src/components/DashboardSidebar.tsx
+++ b/apps/web/src/components/DashboardSidebar.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  createContext,
+  useContext,
+} from "react";
+
+// ── Nav items ────────────────────────────────────────────────────────────────
+
+const NAV_ITEMS = [
+  {
+    label: "Overview",
+    href: "/dashboard",
+    exact: true,
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z"
+        />
+      </svg>
+    ),
+  },
+  {
+    label: "Campaigns",
+    href: "/dashboard/campaigns",
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z"
+        />
+      </svg>
+    ),
+  },
+  {
+    label: "Donors",
+    href: "/dashboard/donors",
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"
+        />
+      </svg>
+    ),
+  },
+  {
+    label: "Donations",
+    href: "/dashboard/donations",
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z"
+        />
+      </svg>
+    ),
+  },
+  {
+    label: "Settings",
+    href: "/dashboard/settings",
+    icon: (
+      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z"
+        />
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+        />
+      </svg>
+    ),
+  },
+];
+
+// ── Context ──────────────────────────────────────────────────────────────────
+
+interface DrawerCtx {
+  open: boolean;
+  openDrawer: () => void;
+  closeDrawer: () => void;
+}
+
+const DrawerContext = createContext<DrawerCtx>({
+  open: false,
+  openDrawer: () => {},
+  closeDrawer: () => {},
+});
+
+// ── Shared nav content ───────────────────────────────────────────────────────
+
+function SidebarContent({
+  pathname,
+  onNavClick,
+}: {
+  pathname: string;
+  onNavClick?: () => void;
+}) {
+  return (
+    <>
+      {/* Logo */}
+      <div className="px-6 py-5 border-b border-gray-100 shrink-0">
+        <Link
+          href="/"
+          className="text-xl font-bold text-give-primary tracking-tight"
+          onClick={onNavClick}
+        >
+          Give
+        </Link>
+      </div>
+
+      {/* Navigation links */}
+      <nav className="flex-1 px-3 py-4 space-y-1 overflow-y-auto">
+        {NAV_ITEMS.map((item) => {
+          const isActive = item.exact
+            ? pathname === item.href
+            : pathname === item.href || pathname.startsWith(item.href + "/");
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onNavClick}
+              aria-current={isActive ? "page" : undefined}
+              className={[
+                "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors",
+                isActive
+                  ? "bg-give-primary/10 text-give-primary"
+                  : "text-gray-600 hover:bg-gray-50 hover:text-give-primary",
+              ].join(" ")}
+            >
+              <span className={isActive ? "text-give-primary" : "text-gray-400"}>
+                {item.icon}
+              </span>
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Footer */}
+      <div className="px-6 py-4 border-t border-gray-100 shrink-0">
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-full bg-give-primary/10 flex items-center justify-center text-xs font-bold text-give-primary shrink-0">
+            A
+          </div>
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-gray-900 truncate">My Nonprofit</div>
+            <div className="text-xs text-gray-400 truncate">Basic plan</div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Mobile hamburger button (consumes context) ───────────────────────────────
+
+/**
+ * Place this inside the dashboard header to get the mobile hamburger trigger.
+ * Must be rendered inside <DashboardSidebarProvider>.
+ */
+export function MobileMenuButton() {
+  const { open, openDrawer } = useContext(DrawerContext);
+  return (
+    <button
+      className="md:hidden text-gray-500 hover:text-gray-700 transition-colors p-1 -ml-1"
+      aria-label="Open navigation menu"
+      aria-expanded={open}
+      aria-controls="mobile-nav-drawer"
+      onClick={openDrawer}
+    >
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+        />
+      </svg>
+    </button>
+  );
+}
+
+// ── Provider ─────────────────────────────────────────────────────────────────
+
+/**
+ * Wraps the dashboard layout. Provides:
+ * - Desktop fixed sidebar (md+)
+ * - Mobile backdrop + slide-in drawer
+ * - DrawerContext for <MobileMenuButton>
+ */
+export function DashboardSidebarProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+
+  const openDrawer = useCallback(() => setOpen(true), []);
+  const closeDrawer = useCallback(() => setOpen(false), []);
+
+  // Close drawer whenever route changes
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  // Lock body scroll while drawer is open
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closeDrawer();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, closeDrawer]);
+
+  return (
+    <DrawerContext.Provider value={{ open, openDrawer, closeDrawer }}>
+      {/* ── Desktop sidebar (hidden on mobile) ─────── */}
+      <aside className="hidden md:flex flex-col w-64 bg-white border-r border-gray-100 fixed inset-y-0 left-0 z-30">
+        <SidebarContent pathname={pathname} />
+      </aside>
+
+      {/* ── Mobile backdrop ──────────────────────────── */}
+      <div
+        aria-hidden="true"
+        onClick={closeDrawer}
+        className={[
+          "fixed inset-0 z-40 bg-black/40 md:hidden transition-opacity duration-300",
+          open ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none",
+        ].join(" ")}
+      />
+
+      {/* ── Mobile slide-in drawer ──────────────────── */}
+      <div
+        id="mobile-nav-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation menu"
+        className={[
+          "fixed inset-y-0 left-0 z-50 flex flex-col w-72 max-w-[85vw] bg-white shadow-xl md:hidden",
+          "transition-transform duration-300 ease-in-out",
+          open ? "translate-x-0" : "-translate-x-full",
+        ].join(" ")}
+      >
+        {/* Close ✕ */}
+        <button
+          className="absolute top-4 right-4 p-1 text-gray-400 hover:text-gray-600 transition-colors z-10"
+          aria-label="Close navigation menu"
+          onClick={closeDrawer}
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+
+        <SidebarContent pathname={pathname} onNavClick={closeDrawer} />
+      </div>
+
+      {/* Layout children (header + main) */}
+      {children}
+    </DrawerContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

Implements a fully functional mobile navigation for the dashboard. Previously the sidebar was `hidden md:flex` and the hamburger button did nothing — the dashboard was unusable on phones.

## Changes

### New: `apps/web/src/components/DashboardSidebar.tsx` (client component)
- **`DashboardSidebarProvider`** — wraps the dashboard layout; owns all drawer state (open/close), body scroll lock, Escape key handling, and auto-close on route change
- **`MobileMenuButton`** — consumes drawer context; renders the hamburger ☰ button, only visible on mobile (`md:hidden`)
- **`SidebarContent`** (internal) — shared nav list used by both desktop sidebar and mobile drawer, with active-route highlighting via `usePathname()`

### Updated: `apps/web/src/app/dashboard/layout.tsx`
- Wraps everything in `<DashboardSidebarProvider>`
- Places `<MobileMenuButton>` in the header (left side, mobile only)
- Desktop layout unchanged (`md:ml-64`, `hidden md:flex` sidebar)

## Mobile UX
- Hamburger button (☰) in top-left of header on mobile
- Slide-in drawer from left (`w-72`, `max-w-[85vw]`) — fits 375px screens
- Semi-transparent black backdrop; click outside → close
- ✕ close button inside drawer
- Escape key closes drawer
- Navigating to a route auto-closes drawer
- Body scroll locked while drawer is open
- Smooth `transition-transform duration-300 ease-in-out` animation

## Active Route Highlighting
- Uses `usePathname()` for real-time active state
- Exact match for `/dashboard`, prefix match for nested routes
- Active item: `bg-give-primary/10 text-give-primary` (icon also highlighted)

Closes #60