### PR TITLE
feat: Beta waitlist signup + landing page conversion improvements

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 
 import { healthRoutes } from "./routes/health.js";
+import { waitlistRoutes } from "./routes/waitlist.js";
 import { orgRoutes } from "./routes/orgs.js";
 import { campaignRoutes } from "./routes/campaigns.js";
 import { donationRoutes } from "./routes/donations.js";
@@ -33,6 +34,10 @@ app.use(
 
 // Health check
 app.route("/api/health", healthRoutes);
+
+// Waitlist signup — public, rate limited
+app.use("/api/waitlist", publicRateLimit);
+app.route("/api/waitlist", waitlistRoutes);
 
 // Stripe webhooks & connect — exempt from rate limiting (Stripe IPs are trusted)
 // Must stay public; signature verification happens inside the route handler.

--- a/apps/api/src/routes/waitlist.ts
+++ b/apps/api/src/routes/waitlist.ts
@@ -1,0 +1,50 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { prisma } from "@give/db";
+
+export const waitlistRoutes = new Hono();
+
+const WaitlistSchema = z.object({
+  email: z.string().email({ message: "Valid email is required" }),
+  orgName: z.string().min(1, { message: "Organization name is required" }).max(200),
+});
+
+waitlistRoutes.post("/", async (c) => {
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: { code: "INVALID_JSON", message: "Request body must be valid JSON" } }, 400);
+  }
+
+  const parsed = WaitlistSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Invalid request",
+          details: parsed.error.flatten().fieldErrors,
+        },
+      },
+      400
+    );
+  }
+
+  const { email, orgName } = parsed.data;
+
+  try {
+    const entry = await prisma.waitlistEntry.upsert({
+      where: { email },
+      update: { orgName },
+      create: { email, orgName },
+    });
+
+    // TODO: Send confirmation email via Resend (deferred)
+
+    return c.json({ success: true, id: entry.id }, 201);
+  } catch (err) {
+    console.error("[waitlist] DB error:", err);
+    return c.json({ error: { code: "INTERNAL_ERROR", message: "Failed to save waitlist entry" } }, 500);
+  }
+});

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://givefundraising.com/sitemap.xml

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://givefundraising.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://givefundraising.com/sign-in</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://givefundraising.com/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://givefundraising.com/terms</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,13 +8,47 @@ const inter = Inter({
   variable: "--font-inter",
 });
 
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://givefundraising.com";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
   icons: {
     icon: "/favicon.svg",
   },
   title: "Give — Fundraising That's Fair",
   description:
     "Transparent nonprofit fundraising with 1% fees. No hidden donor tips, no gotchas. Donation forms, CRM, events, peer-to-peer, and automatic payouts — everything your nonprofit needs.",
+  keywords: [
+    "nonprofit fundraising",
+    "donation platform",
+    "fundraising software",
+    "transparent fees",
+    "donor management",
+  ],
+  openGraph: {
+    type: "website",
+    url: siteUrl,
+    siteName: "Give",
+    title: "Give — Fundraising That's Fair",
+    description:
+      "1% platform fee. No hidden donor tips. No gotchas. The nonprofit fundraising platform built on transparency.",
+    images: [
+      {
+        url: "/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "Give — Fundraising That's Fair",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@givefundraising",
+    title: "Give — Fundraising That's Fair",
+    description:
+      "1% platform fee. No hidden donor tips. No gotchas. The nonprofit fundraising platform built on transparency.",
+    images: ["/og-image.png"],
+  },
 };
 
 export default function RootLayout({

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import Link from "next/link";
+import { useState } from "react";
 
 const FEATURES = [
   {
@@ -48,7 +51,7 @@ const COMPARISON = [
   {
     name: "Zeffy",
     highlight: false,
-    fee: '0%',
+    fee: "0%",
     feeNote: "but...",
     donorTips: "17% default tip",
     monthlyFee: "$0",
@@ -77,25 +80,223 @@ const COMPARISON = [
   },
 ];
 
+const TESTIMONIALS = [
+  {
+    quote:
+      "We switched from Givebutter and couldn't be happier. The fees are transparent and our donors trust us more because of it. Give is exactly what the nonprofit world has been missing.",
+    author: "Sarah M.",
+    role: "Executive Director, Sunrise Community Foundation",
+    initials: "SM",
+  },
+  {
+    quote:
+      "The dashboard is intuitive, payouts are automatic, and support actually responds. It took us 20 minutes to set up our first campaign. Wish we'd found this years ago.",
+    author: "David K.",
+    role: "Development Manager, Westside Animal Rescue",
+    initials: "DK",
+  },
+  {
+    quote:
+      "Our board was skeptical about switching platforms mid-year. After one quarter on Give, they asked why we didn't do it sooner. The reporting alone is worth it.",
+    author: "Priya R.",
+    role: "COO, Open Door Youth Services",
+    initials: "PR",
+  },
+];
+
+const HOW_IT_WORKS = [
+  {
+    step: "1",
+    title: "Sign up & connect your bank",
+    description:
+      "Create your organization profile and connect your bank account via Stripe. Takes under 5 minutes — no paperwork, no waiting.",
+  },
+  {
+    step: "2",
+    title: "Launch your campaigns",
+    description:
+      "Build beautiful donation forms, set up peer-to-peer campaigns, or create event ticketing pages. Embed anywhere or share a direct link.",
+  },
+  {
+    step: "3",
+    title: "Watch the donations roll in",
+    description:
+      "Donors give, you get paid automatically on a daily or weekly schedule. Track everything in real-time from your dashboard.",
+  },
+];
+
+const FAQ = [
+  {
+    q: "What does 'beta' mean for my organization?",
+    a: "During beta, you get full access to all features at no cost beyond the standard processing fees. We're gathering feedback to shape the product. Your data is real, payouts are real — nothing is simulated.",
+  },
+  {
+    q: "Are there any setup fees or contracts?",
+    a: "None. Give is pay-as-you-go. The 1% platform fee only applies when you process donations. No monthly minimums, no annual contracts, no cancellation fees.",
+  },
+  {
+    q: "What about payment processing fees?",
+    a: "Stripe handles payment processing at their standard rates: 2.2% + $0.30 for card payments, 0.8% for ACH bank transfers. These are separate from Give's platform fee and go directly to Stripe.",
+  },
+  {
+    q: "Can donors cover the fees?",
+    a: "Yes. Give includes a built-in 'cover the fees' option on all donation forms. When donors opt in, you receive 100% of their intended donation amount.",
+  },
+  {
+    q: "How is Give different from Zeffy's 0% model?",
+    a: "Zeffy's forms default to a 17% donor tip that goes to Zeffy — not your organization. Many donors think they're giving more to you when they're not. Give charges a transparent 1% with zero hidden tips.",
+  },
+];
+
+function WaitlistModal({ onClose }: { onClose: () => void }) {
+  const [orgName, setOrgName] = useState("");
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus("loading");
+    setErrorMsg("");
+
+    try {
+      const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "";
+      const res = await fetch(`${apiBase}/api/waitlist`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orgName, email }),
+      });
+
+      if (res.ok) {
+        setStatus("success");
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setErrorMsg(
+          (data as { error?: { message?: string } }).error?.message ?? "Something went wrong. Please try again."
+        );
+        setStatus("error");
+      }
+    } catch {
+      setErrorMsg("Network error. Please check your connection and try again.");
+      setStatus("error");
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md p-8 relative">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 transition-colors"
+          aria-label="Close"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        {status === "success" ? (
+          <div className="text-center py-6">
+            <div className="w-16 h-16 bg-give-accent/10 rounded-full flex items-center justify-center mx-auto mb-4">
+              <svg className="w-8 h-8 text-give-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <h3 className="text-xl font-bold text-gray-900 mb-2">You&apos;re on the list!</h3>
+            <p className="text-gray-500 text-sm">
+              We&apos;ll reach out with early access as we open up spots. Thanks for your interest in Give.
+            </p>
+            <button
+              onClick={onClose}
+              className="mt-6 text-give-primary font-semibold text-sm hover:underline"
+            >
+              Close
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="mb-6">
+              <h3 className="text-2xl font-bold text-gray-900">Join the beta waitlist</h3>
+              <p className="text-gray-500 text-sm mt-1">
+                Get early access to Give. We&apos;ll notify you when your spot is ready.
+              </p>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="orgName">
+                  Organization name
+                </label>
+                <input
+                  id="orgName"
+                  type="text"
+                  value={orgName}
+                  onChange={(e) => setOrgName(e.target.value)}
+                  placeholder="Sunrise Community Foundation"
+                  required
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-give-primary/30 focus:border-give-primary transition"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1" htmlFor="email">
+                  Work email
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@yourorg.org"
+                  required
+                  className="w-full px-4 py-3 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-give-primary/30 focus:border-give-primary transition"
+                />
+              </div>
+
+              {status === "error" && (
+                <p className="text-sm text-red-600 bg-red-50 rounded-lg px-4 py-2">{errorMsg}</p>
+              )}
+
+              <button
+                type="submit"
+                disabled={status === "loading"}
+                className="w-full py-3 px-6 bg-give-primary text-white font-semibold rounded-lg hover:bg-give-primary-dark transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {status === "loading" ? "Joining…" : "Request early access"}
+              </button>
+            </form>
+
+            <p className="text-xs text-gray-400 mt-4 text-center">
+              No spam. No credit card. Just an early access invite.
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function HomePage() {
+  const [showWaitlist, setShowWaitlist] = useState(false);
+
   return (
     <div className="min-h-screen">
+      {showWaitlist && <WaitlistModal onClose={() => setShowWaitlist(false)} />}
+
       {/* ── Navigation ─────────────────────────────────── */}
-      <nav className="border-b border-gray-100 bg-white/80 backdrop-blur-md sticky top-0 z-50">
+      <nav className="border-b border-gray-100 bg-white/80 backdrop-blur-md sticky top-0 z-40">
         <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
           <Link href="/" className="text-2xl font-bold text-give-primary tracking-tight">
             Give
           </Link>
           <div className="hidden md:flex items-center gap-8 text-sm font-medium text-gray-600">
-            <a href="#features" className="hover:text-give-primary transition-colors">
-              Features
-            </a>
-            <a href="#pricing" className="hover:text-give-primary transition-colors">
-              Pricing
-            </a>
-            <a href="#compare" className="hover:text-give-primary transition-colors">
-              Compare
-            </a>
+            <a href="#features" className="hover:text-give-primary transition-colors">Features</a>
+            <a href="#how-it-works" className="hover:text-give-primary transition-colors">How it works</a>
+            <a href="#pricing" className="hover:text-give-primary transition-colors">Pricing</a>
+            <a href="#compare" className="hover:text-give-primary transition-colors">Compare</a>
+            <a href="#faq" className="hover:text-give-primary transition-colors">FAQ</a>
           </div>
           <div className="flex items-center gap-3">
             <Link
@@ -104,12 +305,12 @@ export default function HomePage() {
             >
               Log In
             </Link>
-            <Link
-              href="/dashboard"
+            <button
+              onClick={() => setShowWaitlist(true)}
               className="text-sm font-semibold text-white bg-give-primary hover:bg-give-primary-dark transition-colors px-5 py-2.5 rounded-lg"
             >
-              Start Fundraising
-            </Link>
+              Join Beta
+            </button>
           </div>
         </div>
       </nav>
@@ -118,31 +319,34 @@ export default function HomePage() {
       <section className="relative overflow-hidden bg-gradient-to-b from-blue-50/80 to-give-bg">
         <div className="max-w-6xl mx-auto px-6 pt-24 pb-20 md:pt-32 md:pb-28">
           <div className="max-w-3xl mx-auto text-center">
+            <div className="inline-flex items-center gap-2 bg-give-primary/10 text-give-primary text-xs font-semibold px-4 py-2 rounded-full mb-6">
+              <span className="w-2 h-2 bg-give-accent rounded-full animate-pulse" />
+              Now in beta — limited early access
+            </div>
             <h1 className="text-5xl md:text-7xl font-extrabold tracking-tight text-gray-900 leading-tight">
               Fundraising{" "}
               <span className="text-give-primary">that&apos;s fair.</span>
             </h1>
             <p className="mt-6 text-lg md:text-xl text-gray-600 leading-relaxed max-w-2xl mx-auto">
               1% platform fee. No hidden donor tips. No gotchas. Every dollar your
-              supporters give goes where they expect it to go &mdash; to your
-              mission.
+              supporters give goes where they expect it to go &mdash; to your mission.
             </p>
             <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-              <Link
-                href="/dashboard"
+              <button
+                onClick={() => setShowWaitlist(true)}
                 className="w-full sm:w-auto text-center text-base font-semibold text-white bg-give-primary hover:bg-give-primary-dark transition-colors px-8 py-4 rounded-xl shadow-lg shadow-give-primary/25"
               >
-                Start Fundraising
-              </Link>
+                Request early access
+              </button>
               <a
-                href="#pricing"
+                href="#how-it-works"
                 className="w-full sm:w-auto text-center text-base font-semibold text-give-primary border-2 border-give-primary/20 hover:border-give-primary/40 transition-colors px-8 py-4 rounded-xl"
               >
-                See Pricing
+                See how it works
               </a>
             </div>
             <p className="mt-6 text-sm text-gray-400">
-              No credit card required. Set up in under 5 minutes.
+              Free during beta. No credit card required.
             </p>
           </div>
         </div>
@@ -197,12 +401,84 @@ export default function HomePage() {
                 <div className="w-12 h-12 bg-give-primary/10 rounded-xl flex items-center justify-center text-give-primary mb-5">
                   {feature.icon}
                 </div>
-                <h3 className="text-xl font-semibold text-gray-900 mb-3">
-                  {feature.title}
-                </h3>
-                <p className="text-gray-500 leading-relaxed">
-                  {feature.description}
-                </p>
+                <h3 className="text-xl font-semibold text-gray-900 mb-3">{feature.title}</h3>
+                <p className="text-gray-500 leading-relaxed">{feature.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── How It Works ───────────────────────────────── */}
+      <section id="how-it-works" className="py-20 md:py-28 bg-white">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900">
+              Up and running in minutes
+            </h2>
+            <p className="mt-4 text-lg text-gray-500 max-w-2xl mx-auto">
+              No sales calls. No long onboarding. Just a fast, painless setup.
+            </p>
+          </div>
+          <div className="grid md:grid-cols-3 gap-10">
+            {HOW_IT_WORKS.map((step) => (
+              <div key={step.step} className="flex flex-col items-start">
+                <div className="w-12 h-12 rounded-full bg-give-primary text-white font-bold text-lg flex items-center justify-center mb-5">
+                  {step.step}
+                </div>
+                <h3 className="text-xl font-semibold text-gray-900 mb-3">{step.title}</h3>
+                <p className="text-gray-500 leading-relaxed">{step.description}</p>
+              </div>
+            ))}
+          </div>
+          <div className="text-center mt-14">
+            <button
+              onClick={() => setShowWaitlist(true)}
+              className="inline-flex items-center gap-2 text-base font-semibold text-white bg-give-primary hover:bg-give-primary-dark transition-colors px-8 py-4 rounded-xl shadow-lg shadow-give-primary/20"
+            >
+              Get started free
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8l4 4m0 0l-4 4m4-4H3" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Testimonials ───────────────────────────────── */}
+      <section className="py-20 md:py-28 bg-give-bg">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900">
+              Nonprofits love Give
+            </h2>
+            <p className="mt-4 text-lg text-gray-500">
+              Don&apos;t take our word for it.
+            </p>
+          </div>
+          <div className="grid md:grid-cols-3 gap-8">
+            {TESTIMONIALS.map((t) => (
+              <div
+                key={t.author}
+                className="bg-white rounded-2xl border border-gray-100 p-8 flex flex-col"
+              >
+                <div className="flex mb-4">
+                  {[...Array(5)].map((_, i) => (
+                    <svg key={i} className="w-5 h-5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+                      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                    </svg>
+                  ))}
+                </div>
+                <p className="text-gray-700 leading-relaxed flex-1 italic mb-6">&ldquo;{t.quote}&rdquo;</p>
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-full bg-give-primary/10 text-give-primary font-bold text-sm flex items-center justify-center flex-shrink-0">
+                    {t.initials}
+                  </div>
+                  <div>
+                    <div className="text-sm font-semibold text-gray-900">{t.author}</div>
+                    <div className="text-xs text-gray-500">{t.role}</div>
+                  </div>
+                </div>
               </div>
             ))}
           </div>
@@ -224,16 +500,12 @@ export default function HomePage() {
           <div className="grid md:grid-cols-2 gap-8 max-w-4xl mx-auto">
             {/* Basic */}
             <div className="rounded-2xl border-2 border-gray-200 p-8 bg-give-bg">
-              <div className="text-sm font-semibold text-give-primary uppercase tracking-wider mb-2">
-                Basic
-              </div>
+              <div className="text-sm font-semibold text-give-primary uppercase tracking-wider mb-2">Basic</div>
               <div className="flex items-baseline gap-1 mb-1">
                 <span className="text-5xl font-extrabold text-gray-900">1%</span>
                 <span className="text-gray-500">per donation</span>
               </div>
-              <p className="text-sm text-gray-500 mb-6">
-                + payment processing (2.2% + $0.30 card, 0.8% ACH)
-              </p>
+              <p className="text-sm text-gray-500 mb-6">+ payment processing (2.2% + $0.30 card, 0.8% ACH)</p>
               <ul className="space-y-3 text-sm text-gray-700 mb-8">
                 {[
                   "Unlimited donation forms",
@@ -255,28 +527,24 @@ export default function HomePage() {
                   </li>
                 ))}
               </ul>
-              <Link
-                href="/dashboard"
+              <button
+                onClick={() => setShowWaitlist(true)}
                 className="block w-full text-center py-3 px-6 rounded-lg border-2 border-give-primary text-give-primary font-semibold hover:bg-give-primary hover:text-white transition-colors"
               >
-                Get Started
-              </Link>
+                Join beta waitlist
+              </button>
             </div>
             {/* Pro */}
             <div className="rounded-2xl border-2 border-give-primary p-8 bg-white relative shadow-lg shadow-give-primary/10">
               <div className="absolute -top-3 right-8 bg-give-accent text-white text-xs font-bold px-3 py-1 rounded-full">
                 Popular
               </div>
-              <div className="text-sm font-semibold text-give-primary uppercase tracking-wider mb-2">
-                Pro
-              </div>
+              <div className="text-sm font-semibold text-give-primary uppercase tracking-wider mb-2">Pro</div>
               <div className="flex items-baseline gap-1 mb-1">
                 <span className="text-5xl font-extrabold text-gray-900">2%</span>
                 <span className="text-gray-500">per donation</span>
               </div>
-              <p className="text-sm text-gray-500 mb-6">
-                + payment processing (2.2% + $0.30 card, 0.8% ACH)
-              </p>
+              <p className="text-sm text-gray-500 mb-6">+ payment processing (2.2% + $0.30 card, 0.8% ACH)</p>
               <ul className="space-y-3 text-sm text-gray-700 mb-8">
                 {[
                   "Everything in Basic, plus:",
@@ -298,12 +566,12 @@ export default function HomePage() {
                   </li>
                 ))}
               </ul>
-              <Link
-                href="/dashboard"
+              <button
+                onClick={() => setShowWaitlist(true)}
                 className="block w-full text-center py-3 px-6 rounded-lg bg-give-primary text-white font-semibold hover:bg-give-primary-dark transition-colors"
               >
-                Get Started
-              </Link>
+                Join beta waitlist
+              </button>
             </div>
           </div>
         </div>
@@ -340,50 +608,25 @@ export default function HomePage() {
               </thead>
               <tbody className="text-gray-600">
                 <tr className="border-b border-gray-100">
-                  <td className="py-4 pr-4 font-medium text-gray-700">
-                    Platform Fee
-                  </td>
+                  <td className="py-4 pr-4 font-medium text-gray-700">Platform Fee</td>
                   {COMPARISON.map((c) => (
-                    <td
-                      key={c.name}
-                      className={`text-center py-4 px-4 ${
-                        c.highlight ? "font-bold text-give-primary" : ""
-                      }`}
-                    >
+                    <td key={c.name} className={`text-center py-4 px-4 ${c.highlight ? "font-bold text-give-primary" : ""}`}>
                       {c.fee}
                     </td>
                   ))}
                 </tr>
                 <tr className="border-b border-gray-100">
-                  <td className="py-4 pr-4 font-medium text-gray-700">
-                    Hidden Donor Tips
-                  </td>
+                  <td className="py-4 pr-4 font-medium text-gray-700">Hidden Donor Tips</td>
                   {COMPARISON.map((c) => (
-                    <td
-                      key={c.name}
-                      className={`text-center py-4 px-4 ${
-                        c.highlight
-                          ? "font-bold text-give-accent"
-                          : c.donorTips !== "None"
-                            ? "text-red-500"
-                            : ""
-                      }`}
-                    >
+                    <td key={c.name} className={`text-center py-4 px-4 ${c.highlight ? "font-bold text-give-accent" : c.donorTips !== "None" ? "text-red-500" : ""}`}>
                       {c.donorTips}
                     </td>
                   ))}
                 </tr>
                 <tr className="border-b border-gray-100">
-                  <td className="py-4 pr-4 font-medium text-gray-700">
-                    Monthly Fee
-                  </td>
+                  <td className="py-4 pr-4 font-medium text-gray-700">Monthly Fee</td>
                   {COMPARISON.map((c) => (
-                    <td
-                      key={c.name}
-                      className={`text-center py-4 px-4 ${
-                        c.highlight ? "font-bold text-give-accent" : ""
-                      }`}
-                    >
+                    <td key={c.name} className={`text-center py-4 px-4 ${c.highlight ? "font-bold text-give-accent" : ""}`}>
                       {c.monthlyFee}
                     </td>
                   ))}
@@ -391,12 +634,7 @@ export default function HomePage() {
                 <tr className="border-b border-gray-100">
                   <td className="py-4 pr-4 font-medium text-gray-700">Features</td>
                   {COMPARISON.map((c) => (
-                    <td
-                      key={c.name}
-                      className={`text-center py-4 px-4 ${
-                        c.highlight ? "font-bold text-give-primary" : ""
-                      }`}
-                    >
+                    <td key={c.name} className={`text-center py-4 px-4 ${c.highlight ? "font-bold text-give-primary" : ""}`}>
                       {c.features}
                     </td>
                   ))}
@@ -404,18 +642,41 @@ export default function HomePage() {
                 <tr>
                   <td className="py-4 pr-4 font-medium text-gray-700">Payouts</td>
                   {COMPARISON.map((c) => (
-                    <td
-                      key={c.name}
-                      className={`text-center py-4 px-4 ${
-                        c.highlight ? "font-bold text-give-accent" : ""
-                      }`}
-                    >
+                    <td key={c.name} className={`text-center py-4 px-4 ${c.highlight ? "font-bold text-give-accent" : ""}`}>
                       {c.payouts}
                     </td>
                   ))}
                 </tr>
               </tbody>
             </table>
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ────────────────────────────────────────── */}
+      <section id="faq" className="py-20 md:py-28 bg-white">
+        <div className="max-w-3xl mx-auto px-6">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900">
+              Frequently asked questions
+            </h2>
+          </div>
+          <div className="space-y-6">
+            {FAQ.map((item) => (
+              <div key={item.q} className="border border-gray-100 rounded-xl p-6">
+                <h3 className="font-semibold text-gray-900 mb-2">{item.q}</h3>
+                <p className="text-gray-500 leading-relaxed text-sm">{item.a}</p>
+              </div>
+            ))}
+          </div>
+          <div className="text-center mt-12">
+            <p className="text-gray-500 text-sm mb-4">Still have questions?</p>
+            <a
+              href="mailto:hello@givefundraising.com"
+              className="text-give-primary font-semibold text-sm hover:underline"
+            >
+              Get in touch →
+            </a>
           </div>
         </div>
       </section>
@@ -428,15 +689,15 @@ export default function HomePage() {
           </h2>
           <p className="mt-4 text-lg text-blue-100 max-w-2xl mx-auto">
             Join nonprofits that believe donors deserve to know where their money
-            goes. Set up in under 5 minutes.
+            goes. Free during beta.
           </p>
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Link
-              href="/dashboard"
+            <button
+              onClick={() => setShowWaitlist(true)}
               className="w-full sm:w-auto text-center text-base font-semibold text-give-primary bg-white hover:bg-gray-50 transition-colors px-8 py-4 rounded-xl"
             >
-              Start Fundraising
-            </Link>
+              Request early access
+            </button>
             <a
               href="#pricing"
               className="w-full sm:w-auto text-center text-base font-semibold text-white border-2 border-white/30 hover:border-white/60 transition-colors px-8 py-4 rounded-xl"
@@ -453,21 +714,12 @@ export default function HomePage() {
           <div className="flex flex-col md:flex-row items-center justify-between gap-6">
             <div className="text-xl font-bold text-white tracking-tight">Give</div>
             <div className="flex items-center gap-6 text-sm">
-              <a href="#features" className="hover:text-white transition-colors">
-                Features
-              </a>
-              <a href="#pricing" className="hover:text-white transition-colors">
-                Pricing
-              </a>
-              <a href="#compare" className="hover:text-white transition-colors">
-                Compare
-              </a>
-              <Link href="/privacy" className="hover:text-white transition-colors">
-                Privacy
-              </Link>
-              <Link href="/terms" className="hover:text-white transition-colors">
-                Terms
-              </Link>
+              <a href="#features" className="hover:text-white transition-colors">Features</a>
+              <a href="#pricing" className="hover:text-white transition-colors">Pricing</a>
+              <a href="#compare" className="hover:text-white transition-colors">Compare</a>
+              <a href="#faq" className="hover:text-white transition-colors">FAQ</a>
+              <Link href="/privacy" className="hover:text-white transition-colors">Privacy</Link>
+              <Link href="/terms" className="hover:text-white transition-colors">Terms</Link>
             </div>
             <div className="text-sm">
               &copy; {new Date().getFullYear()} Give. Fundraising that&apos;s fair.

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -269,3 +269,13 @@ enum PaymentMethodType {
   APPLE_PAY
   GOOGLE_PAY
 }
+
+model WaitlistEntry {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  orgName   String
+  createdAt DateTime @default(now())
+
+  @@index([createdAt])
+  @@map("waitlist_entries")
+}


### PR DESCRIPTION
Closes #64

## Summary
- **WaitlistEntry model** added to Prisma schema + Prisma client regenerated
- **POST /api/waitlist** — public endpoint, rate-limited via existing `publicRateLimit` middleware, validates `orgName` + `email` (zod), upserts to avoid dupes
- **Waitlist modal** replaces "Start Fundraising" hero CTAs (React state-driven, accessible, success state)
- **Testimonials section** — 3 placeholder quotes with star ratings
- **How It Works** — 3-step section
- **FAQ section** — 5 questions covering beta, pricing, Zeffy comparison
- **OG/Twitter meta tags** in layout.tsx (`metadataBase`, `openGraph`, `twitter`)
- **sitemap.xml** and **robots.txt** added to `apps/web/public/`

## Not included
- Email confirmation: TODO (Resend integration deferred, comment left in waitlist.ts)
