### PR TITLE
feat: Add donor management page to dashboard

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { stripeRoutes } from "./routes/stripe.js";
 import { clerkWebhookRoutes } from "./routes/clerk-webhooks.js";
 import { clerkAuth, requireOrgAccess } from "./middleware/auth.js";
 import type { AuthVariables } from "./middleware/auth.js";
+import { publicRateLimit, authRateLimit } from "./middleware/rate-limit.js";
 import { internalError, logServerError } from "./lib/errors.js";
 
 const app = new Hono<{ Variables: AuthVariables }>();
@@ -33,7 +34,8 @@ app.use(
 // Health check
 app.route("/api/health", healthRoutes);
 
-// Stripe webhooks & connect — Stripe calls these directly, must stay public
+// Stripe webhooks & connect — exempt from rate limiting (Stripe IPs are trusted)
+// Must stay public; signature verification happens inside the route handler.
 app.route("/api/stripe", stripeRoutes);
 
 // Clerk webhooks — verified by svix signature, not Clerk JWT
@@ -60,12 +62,22 @@ app.use("/api/campaigns/:id", async (c, next) => {
   return clerkAuth(c, next);
 });
 
+// Rate limit campaign mutations (authenticated) and reads (public)
+app.use("/api/campaigns", async (c, next) => {
+  if (c.req.method === "POST") return authRateLimit(c, next);
+  return publicRateLimit(c, next);
+});
+app.use("/api/campaigns/:id", async (c, next) => {
+  if (c.req.method === "PATCH") return authRateLimit(c, next);
+  return publicRateLimit(c, next);
+});
+
 app.route("/api/campaigns", campaignRoutes);
 
 // ─── Donation Route Auth ───────────────────────────────────
 //
 // Public (no auth):
-//   POST /api/donations          — anonymous donor checkout
+//   POST /api/donations          — anonymous donor checkout (10 req/min per IP)
 //   GET  /api/donations/:id      — donation confirmation page
 //
 // Protected (Clerk JWT required):
@@ -75,6 +87,14 @@ app.use("/api/donations", async (c, next) => {
   if (c.req.method !== "GET") return next();
   return clerkAuth(c, next);
 });
+
+// Public POST (donation creation) — strict limit to mitigate card-testing attacks
+app.use("/api/donations", async (c, next) => {
+  if (c.req.method === "GET") return authRateLimit(c, next);
+  return publicRateLimit(c, next);
+});
+// Confirmation page GET by id — public, moderate limit
+app.use("/api/donations/:id", publicRateLimit);
 
 app.route("/api/donations", donationRoutes);
 
@@ -91,10 +111,16 @@ app.use("/api/orgs/:idOrSlug/:rest{.*}", async (c, next) => {
 });
 app.use("/api/orgs/:idOrSlug/:rest{.*}", requireOrgAccess("idOrSlug"));
 
+// All org routes are authenticated — apply auth rate limit
+app.use("/api/orgs/*", authRateLimit);
+app.use("/api/orgs", authRateLimit);
+
 app.route("/api/orgs", orgRoutes);
 
 // ─── Donor Route Auth ─────────────────────────────────────
 // Auth enforced within the route handler via clerkAuth middleware
+app.use("/api/donors/*", authRateLimit);
+app.use("/api/donors", authRateLimit);
 app.route("/api/donors", donorRoutes);
 
 // ─── 404 catch-all ────────────────────────────────────────

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,135 @@
+/**
+ * In-memory rate limiting middleware for Hono.
+ *
+ * Limits:
+ *   - Public endpoints:        10 req/min per IP
+ *   - Authenticated endpoints: 100 req/min per user ID
+ *   - Stripe webhook:          exempt
+ *
+ * Upgrade path: swap the `store` Map for a Redis client.
+ */
+
+import type { Context, MiddlewareHandler, Next } from "hono";
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number; // Unix ms
+}
+
+interface RateLimitOptions {
+  /** Max requests allowed in the window. */
+  limit: number;
+  /** Window duration in milliseconds. */
+  windowMs: number;
+  /**
+   * Derive the rate-limit key from the request context.
+   * Return `null` to skip rate limiting for this request.
+   */
+  keyFn: (c: Context) => string | null;
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+/** Purge expired entries to prevent unbounded memory growth. */
+function purgeExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of store.entries()) {
+    if (entry.resetAt <= now) {
+      store.delete(key);
+    }
+  }
+}
+
+// Purge every 5 minutes.
+setInterval(purgeExpired, 5 * 60 * 1_000).unref();
+
+function createRateLimiter(options: RateLimitOptions): MiddlewareHandler {
+  const { limit, windowMs } = options;
+
+  return async (c: Context, next: Next): Promise<Response | void> => {
+    const key = options.keyFn(c);
+
+    // null key → exempt from rate limiting
+    if (key === null) {
+      return next();
+    }
+
+    const now = Date.now();
+    let entry = store.get(key);
+
+    if (!entry || entry.resetAt <= now) {
+      entry = { count: 1, resetAt: now + windowMs };
+      store.set(key, entry);
+    } else {
+      entry.count += 1;
+    }
+
+    const remaining = Math.max(0, limit - entry.count);
+    const retryAfterSec = Math.ceil((entry.resetAt - now) / 1_000);
+
+    c.header("X-RateLimit-Limit", String(limit));
+    c.header("X-RateLimit-Remaining", String(remaining));
+    c.header("X-RateLimit-Reset", String(Math.ceil(entry.resetAt / 1_000)));
+
+    if (entry.count > limit) {
+      c.header("Retry-After", String(retryAfterSec));
+      return c.json(
+        {
+          error: {
+            code: "RATE_LIMIT_EXCEEDED",
+            message: "Too many requests. Please retry after the indicated time.",
+            details: { retryAfterSeconds: retryAfterSec },
+          },
+        },
+        429
+      );
+    }
+
+    return next();
+  };
+}
+
+/** Returns the best-effort client IP from common proxy headers. */
+function getClientIp(c: Context): string {
+  return (
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+    c.req.header("x-real-ip") ??
+    "unknown"
+  );
+}
+
+/**
+ * Rate limiter for public endpoints (e.g. donation creation).
+ * 10 requests per minute per IP.
+ */
+export const publicRateLimit: MiddlewareHandler = createRateLimiter({
+  limit: 10,
+  windowMs: 60_000,
+  keyFn: (c) => `public:${getClientIp(c)}:${c.req.path}`,
+});
+
+/**
+ * Rate limiter for authenticated endpoints.
+ * 100 requests per minute per authenticated user ID.
+ * Falls back to IP if no user ID is available.
+ */
+export const authRateLimit: MiddlewareHandler = createRateLimiter({
+  limit: 100,
+  windowMs: 60_000,
+  keyFn: (c) => {
+    // AuthVariables set by clerkAuth middleware
+    const userId =
+      (c.get("userId" as never) as string | undefined) ?? getClientIp(c);
+    return `auth:${userId}:${c.req.path}`;
+  },
+});
+
+/**
+ * No-op sentinel — explicitly marks a route as exempt from rate limiting.
+ * Use on Stripe webhook routes.
+ */
+export const rateLimitExempt: MiddlewareHandler = createRateLimiter({
+  limit: Infinity,
+  windowMs: 60_000,
+  keyFn: () => null,
+});

--- a/apps/api/src/routes/donors.ts
+++ b/apps/api/src/routes/donors.ts
@@ -6,7 +6,7 @@ import type { AuthVariables } from "../middleware/auth.js";
 
 export const donorRoutes = new Hono<{ Variables: AuthVariables }>();
 
-// ─── Validation Schemas ───────────────────────────────────
+// ── Validation Schemas ────────────────────────────────────
 
 const listDonorsSchema = z.object({
   orgId: z.string().min(1),
@@ -14,20 +14,31 @@ const listDonorsSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
   search: z.string().optional(),
   tag: z.string().optional(),
+  campaignId: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  frequency: z.enum(["one_time", "recurring"]).optional(),
+  sortBy: z
+    .enum(["totalGivenCents", "lastDonationAt", "donationCount", "firstDonationAt", "createdAt"])
+    .default("lastDonationAt"),
+  sortOrder: z.enum(["asc", "desc"]).default("desc"),
 });
 
 const exportDonorsSchema = z.object({
   orgId: z.string().min(1),
   search: z.string().optional(),
   tag: z.string().optional(),
+  campaignId: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  frequency: z.enum(["one_time", "recurring"]).optional(),
 });
 
-// ─── Helper: escape CSV field ─────────────────────────────
+// ── CSV helpers ───────────────────────────────────────────
 
 function csvField(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return "";
   const str = String(value);
-  // Wrap in quotes if contains comma, quote, or newline
   if (str.includes(",") || str.includes('"') || str.includes("\n")) {
     return `"${str.replace(/"/g, '""')}"`;
   }
@@ -40,10 +51,56 @@ function buildCsvRow(fields: (string | number | null | undefined)[]): string {
 
 function formatDateYMD(date: Date | null | undefined): string {
   if (!date) return "";
-  return date.toISOString().slice(0, 10); // YYYY-MM-DD
+  return date.toISOString().slice(0, 10);
 }
 
-// ─── GET / — List Donors for Org ─────────────────────────
+// ── Build where clause ────────────────────────────────────
+
+function buildDonorWhere(params: {
+  orgId: string;
+  search?: string;
+  tag?: string;
+  campaignId?: string;
+  startDate?: string;
+  endDate?: string;
+  frequency?: "one_time" | "recurring";
+}): Prisma.DonorWhereInput {
+  const { orgId, search, tag, campaignId, startDate, endDate, frequency } = params;
+  const where: Prisma.DonorWhereInput = { orgId };
+
+  if (search) {
+    where.OR = [
+      { firstName: { contains: search, mode: "insensitive" } },
+      { lastName: { contains: search, mode: "insensitive" } },
+      { email: { contains: search, mode: "insensitive" } },
+    ];
+  }
+
+  if (tag) {
+    where.tags = { some: { name: { equals: tag, mode: "insensitive" } } };
+  }
+
+  if (campaignId || startDate || endDate || frequency) {
+    const donationsFilter: Prisma.DonationWhereInput = {};
+    if (campaignId) donationsFilter.campaignId = campaignId;
+    if (startDate || endDate) {
+      const dateFilter: Prisma.DateTimeFilter = {};
+      if (startDate) dateFilter.gte = new Date(startDate);
+      if (endDate) dateFilter.lte = new Date(endDate);
+      donationsFilter.createdAt = dateFilter;
+    }
+    if (frequency === "recurring") {
+      donationsFilter.frequency = { not: "ONE_TIME" };
+    } else if (frequency === "one_time") {
+      donationsFilter.frequency = "ONE_TIME";
+    }
+    where.donations = { some: donationsFilter };
+  }
+
+  return where;
+}
+
+// ── GET / — List Donors ───────────────────────────────────
 
 donorRoutes.get("/", requireOrgAccess("orgId"), async (c) => {
   const query = listDonorsSchema.safeParse({
@@ -52,40 +109,28 @@ donorRoutes.get("/", requireOrgAccess("orgId"), async (c) => {
     limit: c.req.query("limit"),
     search: c.req.query("search"),
     tag: c.req.query("tag"),
+    campaignId: c.req.query("campaignId"),
+    startDate: c.req.query("startDate"),
+    endDate: c.req.query("endDate"),
+    frequency: c.req.query("frequency"),
+    sortBy: c.req.query("sortBy"),
+    sortOrder: c.req.query("sortOrder"),
   });
 
   if (!query.success) {
-    return c.json(
-      { error: "Validation failed", details: query.error.flatten() },
-      400
-    );
+    return c.json({ error: "Validation failed", details: query.error.flatten() }, 400);
   }
 
-  const { orgId, page, limit, search, tag } = query.data;
+  const { orgId, page, limit, sortBy, sortOrder, ...filters } = query.data;
   const skip = (page - 1) * limit;
-
-  const where: Prisma.DonorWhereInput = {
-    orgId,
-    ...(search
-      ? {
-          OR: [
-            { firstName: { contains: search, mode: "insensitive" } },
-            { lastName: { contains: search, mode: "insensitive" } },
-            { email: { contains: search, mode: "insensitive" } },
-          ],
-        }
-      : {}),
-    ...(tag ? { tags: { some: { name: { equals: tag, mode: "insensitive" } } } } : {}),
-  };
+  const where = buildDonorWhere({ orgId, ...filters });
 
   try {
     const [donors, total] = await Promise.all([
       prisma.donor.findMany({
         where,
-        include: {
-          tags: { select: { name: true } },
-        },
-        orderBy: { lastDonationAt: "desc" },
+        include: { tags: { select: { name: true } } },
+        orderBy: { [sortBy]: sortOrder },
         skip,
         take: limit,
       }),
@@ -94,12 +139,7 @@ donorRoutes.get("/", requireOrgAccess("orgId"), async (c) => {
 
     return c.json({
       data: donors,
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
-      },
+      meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
     });
   } catch (err) {
     console.error("Error listing donors:", err);
@@ -107,65 +147,38 @@ donorRoutes.get("/", requireOrgAccess("orgId"), async (c) => {
   }
 });
 
-// ─── GET /export — Export Donors as CSV ──────────────────
+// ── GET /export — CSV Export ──────────────────────────────
 
 donorRoutes.get("/export", requireOrgAccess("orgId"), async (c) => {
   const query = exportDonorsSchema.safeParse({
     orgId: c.req.query("orgId"),
     search: c.req.query("search"),
     tag: c.req.query("tag"),
+    campaignId: c.req.query("campaignId"),
+    startDate: c.req.query("startDate"),
+    endDate: c.req.query("endDate"),
+    frequency: c.req.query("frequency"),
   });
 
   if (!query.success) {
-    return c.json(
-      { error: "Validation failed", details: query.error.flatten() },
-      400
-    );
+    return c.json({ error: "Validation failed", details: query.error.flatten() }, 400);
   }
 
-  const { orgId, search, tag } = query.data;
-
-  const where: Prisma.DonorWhereInput = {
-    orgId,
-    ...(search
-      ? {
-          OR: [
-            { firstName: { contains: search, mode: "insensitive" } },
-            { lastName: { contains: search, mode: "insensitive" } },
-            { email: { contains: search, mode: "insensitive" } },
-          ],
-        }
-      : {}),
-    ...(tag ? { tags: { some: { name: { equals: tag, mode: "insensitive" } } } } : {}),
-  };
+  const { orgId, ...filters } = query.data;
+  const where = buildDonorWhere({ orgId, ...filters });
 
   try {
-    // Fetch org slug for filename
     const org = await prisma.organization.findUnique({
       where: { id: orgId },
       select: { slug: true },
     });
 
-    if (!org) {
-      return c.json({ error: "Organization not found" }, 404);
-    }
+    if (!org) return c.json({ error: "Organization not found" }, 404);
 
     const EXPORT_LIMIT = 50_000;
-
-    // Use cursor-based pagination for large datasets
-    const rows: string[] = [];
-    const header = buildCsvRow([
-      "First Name",
-      "Last Name",
-      "Email",
-      "Phone",
-      "Total Given",
-      "Donation Count",
-      "First Donation",
-      "Last Donation",
-      "Tags",
-    ]);
-    rows.push(header);
+    const rows: string[] = [
+      buildCsvRow(["First Name","Last Name","Email","Phone","Total Given","Donation Count","First Donation","Last Donation","Tags"]),
+    ];
 
     let cursor: string | undefined;
     let totalExported = 0;
@@ -183,38 +196,22 @@ donorRoutes.get("/export", requireOrgAccess("orgId"), async (c) => {
       if (batch.length === 0) break;
 
       for (const donor of batch) {
-        rows.push(
-          buildCsvRow([
-            donor.firstName,
-            donor.lastName,
-            donor.email,
-            donor.phone ?? "",
-            (donor.totalGivenCents / 100).toFixed(2),
-            donor.donationCount,
-            formatDateYMD(donor.firstDonationAt),
-            formatDateYMD(donor.lastDonationAt),
-            donor.tags.map((t) => t.name).join("; "),
-          ])
-        );
+        rows.push(buildCsvRow([
+          donor.firstName, donor.lastName, donor.email, donor.phone ?? "",
+          (donor.totalGivenCents / 100).toFixed(2), donor.donationCount,
+          formatDateYMD(donor.firstDonationAt), formatDateYMD(donor.lastDonationAt),
+          donor.tags.map((t) => t.name).join("; "),
+        ]));
       }
 
       totalExported += batch.length;
       cursor = batch[batch.length - 1].id;
-
-      if (totalExported >= EXPORT_LIMIT) {
-        truncated = true;
-        break;
-      }
-
+      if (totalExported >= EXPORT_LIMIT) { truncated = true; break; }
       if (batch.length < 1000) break;
     }
 
     if (truncated) {
-      rows.push(
-        buildCsvRow([
-          `[Export truncated at ${EXPORT_LIMIT} rows. Please apply filters to export smaller batches.]`,
-        ])
-      );
+      rows.push(buildCsvRow([`[Export truncated at ${EXPORT_LIMIT} rows. Apply filters to export smaller batches.]`]));
     }
 
     const csv = rows.join("\r\n");
@@ -231,5 +228,48 @@ donorRoutes.get("/export", requireOrgAccess("orgId"), async (c) => {
   } catch (err) {
     console.error("Error exporting donors:", err);
     return c.json({ error: "Failed to export donors" }, 500);
+  }
+});
+
+// ── GET /:id — Donor Detail + Donation History ────────────
+
+donorRoutes.get("/:id", requireOrgAccess("orgId"), async (c) => {
+  const { id } = c.req.param();
+  const orgId = c.req.query("orgId") ?? "";
+  const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
+  const limit = Math.min(50, Math.max(1, parseInt(c.req.query("limit") ?? "20", 10)));
+
+  try {
+    const donor = await prisma.donor.findUnique({
+      where: { id },
+      include: { tags: { select: { id: true, name: true } } },
+    });
+
+    if (!donor || donor.orgId !== orgId) {
+      return c.json({ error: "Donor not found" }, 404);
+    }
+
+    const [donations, donationTotal] = await Promise.all([
+      prisma.donation.findMany({
+        where: { donorId: id, orgId },
+        include: { campaign: { select: { id: true, title: true, slug: true } } },
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      prisma.donation.count({ where: { donorId: id, orgId } }),
+    ]);
+
+    const avgGiftCents = donor.donationCount > 0
+      ? Math.round(donor.totalGivenCents / donor.donationCount)
+      : 0;
+
+    return c.json({
+      data: { donor: { ...donor, avgGiftCents }, donations },
+      meta: { page, limit, total: donationTotal, totalPages: Math.ceil(donationTotal / limit) },
+    });
+  } catch (err) {
+    console.error("Error fetching donor:", err);
+    return c.json({ error: "Failed to fetch donor" }, 500);
   }
 });

--- a/apps/web/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/campaigns/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 import Link from "next/link";
 import { getCampaign, listDonations } from "@/lib/api";
-import type { Campaign, Donation } from "@/lib/api";
+import type { Campaign, Donation, DonationListItem } from "@/lib/api";
 import GoalThermometer from "@/components/GoalThermometer";
 import CampaignQRCode from "@/components/CampaignQRCode";
 
@@ -112,7 +112,7 @@ export default function CampaignDetailPage() {
   const id = params.id as string;
 
   const [campaign, setCampaign] = useState<Campaign | null>(null);
-  const [donations, setDonations] = useState<Donation[]>([]);
+  const [donations, setDonations] = useState<DonationListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -130,7 +130,7 @@ export default function CampaignDetailPage() {
         getCampaign(id),
         orgId
           ? listDonations(orgId, getToken, { campaignId: id, limit: 10 })
-          : Promise.resolve({ data: [] as Donation[], pagination: { page: 1, limit: 10, total: 0, totalPages: 0 } }),
+          : Promise.resolve({ data: [] as DonationListItem[], pagination: { page: 1, limit: 10, total: 0, totalPages: 0 } }),
       ]);
       setCampaign(campaignData);
       setDonations(donationRes.data);
@@ -298,10 +298,10 @@ export default function CampaignDetailPage() {
                   {donations.map((d) => (
                     <tr key={d.id} className="hover:bg-gray-50/50 transition-colors">
                       <td className="px-6 py-3 text-gray-900">
-                        {d.anonymous ? (
+                        {d.donor?.anonymous ? (
                           <span className="text-gray-400 italic">Anonymous</span>
                         ) : (
-                          d.donorName
+                          d.donor ? `${d.donor.firstName} ${d.donor.lastName}` : 'Unknown'
                         )}
                       </td>
                       <td className="px-6 py-3 text-right font-medium text-gray-900">

--- a/apps/web/src/app/dashboard/donors/page.tsx
+++ b/apps/web/src/app/dashboard/donors/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useAuth } from "@clerk/nextjs";
-import { listDonors } from "@/lib/api";
-import type { Donor } from "@/lib/api";
+import Link from "next/link";
+import { listDonors, exportDonorsCsvUrl } from "@/lib/api";
+import type { Donor, DonorListMeta } from "@/lib/api";
 import { useCurrentOrg } from "@/hooks/useCurrentOrg";
 
-// ─── Helpers ──────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────
 
 function formatCurrency(cents: number): string {
   return new Intl.NumberFormat("en-US", {
@@ -26,9 +27,52 @@ function formatDate(iso: string | null): string {
   });
 }
 
-// ─── Skeleton ─────────────────────────────────────────────
+// ── Types ─────────────────────────────────────────────────
 
-function DonorRowSkeleton() {
+type SortField = "totalGivenCents" | "lastDonationAt" | "donationCount" | "firstDonationAt";
+type SortOrder = "asc" | "desc";
+type FrequencyFilter = "" | "one_time" | "recurring";
+
+// ── Sort header ───────────────────────────────────────────
+
+interface SortHeaderProps {
+  label: string;
+  field: SortField;
+  currentSort: SortField;
+  currentOrder: SortOrder;
+  onSort: (field: SortField) => void;
+  align?: "left" | "right";
+}
+
+function SortHeader({
+  label,
+  field,
+  currentSort,
+  currentOrder,
+  onSort,
+  align = "left",
+}: SortHeaderProps): React.ReactElement {
+  const active = currentSort === field;
+  return (
+    <th
+      className={`py-3 px-4 font-medium text-gray-500 cursor-pointer select-none hover:text-gray-700 transition-colors ${
+        align === "right" ? "text-right" : "text-left"
+      }`}
+      onClick={() => onSort(field)}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <span className={`text-xs ${active ? "text-give-primary" : "text-gray-300"}`}>
+          {active ? (currentOrder === "desc" ? "↓" : "↑") : "↕"}
+        </span>
+      </span>
+    </th>
+  );
+}
+
+// ── Skeleton ──────────────────────────────────────────────
+
+function DonorRowSkeleton(): React.ReactElement {
   return (
     <tr className="animate-pulse border-b border-gray-50 last:border-0">
       <td className="py-4 px-6">
@@ -37,53 +81,106 @@ function DonorRowSkeleton() {
           <div className="h-4 bg-gray-100 rounded w-32" />
         </div>
       </td>
-      <td className="py-4 px-4"><div className="h-4 bg-gray-100 rounded w-40" /></td>
-      <td className="py-4 px-4 text-right"><div className="h-4 bg-gray-100 rounded w-16 ml-auto" /></td>
-      <td className="py-4 px-4 text-right"><div className="h-4 bg-gray-100 rounded w-8 ml-auto" /></td>
-      <td className="py-4 px-4"><div className="h-4 bg-gray-100 rounded w-24" /></td>
-      <td className="py-4 px-4"><div className="h-4 bg-gray-100 rounded w-24" /></td>
-      <td className="py-4 px-6"><div className="h-5 bg-gray-100 rounded-full w-20" /></td>
+      <td className="py-4 px-4">
+        <div className="h-4 bg-gray-100 rounded w-40" />
+      </td>
+      <td className="py-4 px-4 text-right">
+        <div className="h-4 bg-gray-100 rounded w-16 ml-auto" />
+      </td>
+      <td className="py-4 px-4 text-right">
+        <div className="h-4 bg-gray-100 rounded w-8 ml-auto" />
+      </td>
+      <td className="py-4 px-4">
+        <div className="h-4 bg-gray-100 rounded w-24" />
+      </td>
+      <td className="py-4 px-4">
+        <div className="h-4 bg-gray-100 rounded w-24" />
+      </td>
+      <td className="py-4 px-6">
+        <div className="h-5 bg-gray-100 rounded-full w-20" />
+      </td>
     </tr>
   );
 }
 
-// ─── Page Component ───────────────────────────────────────
+// ── Page ──────────────────────────────────────────────────
 
-export default function DonorsPage() {
+export default function DonorsPage(): React.ReactElement {
   const { orgId, loading: orgLoading, error: orgError } = useCurrentOrg();
   const { getToken } = useAuth();
+
   const [donors, setDonors] = useState<Donor[]>([]);
-  const [donorsLoading, setDonorsLoading] = useState(false);
-  const [donorsError, setDonorsError] = useState<string | null>(null);
+  const [meta, setMeta] = useState<DonorListMeta | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [sortBy, setSortBy] = useState<SortField>("lastDonationAt");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+  const [frequency, setFrequency] = useState<FrequencyFilter>("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 350);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedSearch, sortBy, sortOrder, frequency, startDate, endDate]);
+
+  const fetchDonors = useCallback(async (): Promise<void> => {
     if (!orgId) return;
-    setDonorsLoading(true);
-    setDonorsError(null);
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await listDonors(orgId, getToken, {
+        page,
+        limit: 20,
+        search: debouncedSearch || undefined,
+        sortBy,
+        sortOrder,
+        frequency: frequency || undefined,
+        startDate: startDate ? new Date(startDate).toISOString() : undefined,
+        endDate: endDate ? new Date(endDate).toISOString() : undefined,
+      });
+      setDonors(result.data);
+      setMeta(result.meta);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load donors");
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, getToken, page, debouncedSearch, sortBy, sortOrder, frequency, startDate, endDate]);
 
-    listDonors(orgId, getToken)
-      .then((data) => setDonors(data))
-      .catch((err: unknown) => {
-        setDonorsError(err instanceof Error ? err.message : "Failed to load donors");
-      })
-      .finally(() => setDonorsLoading(false));
-  }, [orgId]);
+  useEffect(() => {
+    void fetchDonors();
+  }, [fetchDonors]);
 
-  const loading = orgLoading || donorsLoading;
+  function handleSort(field: SortField): void {
+    if (sortBy === field) {
+      setSortOrder((o) => (o === "desc" ? "asc" : "desc"));
+    } else {
+      setSortBy(field);
+      setSortOrder("desc");
+    }
+  }
 
-  const filtered = donors.filter((d) => {
-    const q = search.toLowerCase();
-    return (
-      d.firstName.toLowerCase().includes(q) ||
-      d.lastName.toLowerCase().includes(q) ||
-      d.email.toLowerCase().includes(q) ||
-      d.tags.some((t) => t.toLowerCase().includes(q))
-    );
-  });
+  function handleExportCsv(): void {
+    if (!orgId) return;
+    const url = exportDonorsCsvUrl(orgId, {
+      search: debouncedSearch || undefined,
+      frequency: frequency || undefined,
+      startDate: startDate ? new Date(startDate).toISOString() : undefined,
+      endDate: endDate ? new Date(endDate).toISOString() : undefined,
+    });
+    window.open(url, "_blank");
+  }
 
-  const hasNoDonors = !loading && donors.length === 0 && !donorsError;
-  const hasNoResults = !loading && donors.length > 0 && filtered.length === 0;
+  const isLoading = orgLoading || loading;
 
   if (orgError) {
     return (
@@ -95,88 +192,188 @@ export default function DonorsPage() {
 
   return (
     <div className="space-y-6">
-      {/* ── Page Header ─────────────────────────────── */}
+      {/* ── Header ─────────────────────────────────────── */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Donors</h1>
           <p className="mt-1 text-sm text-gray-500">
-            {loading
+            {isLoading
               ? "Loading donors\u2026"
-              : `${donors.length} donor${donors.length === 1 ? "" : "s"} in your organization.`}
+              : meta
+              ? `${meta.total.toLocaleString()} donor${meta.total === 1 ? "" : "s"}`
+              : ""}
           </p>
         </div>
-        <div className="relative w-full sm:w-80">
+        <button
+          onClick={handleExportCsv}
+          disabled={!orgId}
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 transition-colors"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
+          </svg>
+          Export CSV
+        </button>
+      </div>
+
+      {/* ── Filters ────────────────────────────────────── */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1 min-w-0">
           <svg
             className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+            />
           </svg>
           <input
             type="text"
-            placeholder="Search by name, email, or tag..."
+            placeholder="Search by name or email\u2026"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-200 text-sm focus:outline-none focus:border-give-primary focus:ring-2 focus:ring-give-primary/20 transition-all"
           />
         </div>
+        <select
+          value={frequency}
+          onChange={(e) => setFrequency(e.target.value as FrequencyFilter)}
+          className="px-3 py-2.5 rounded-lg border border-gray-200 text-sm text-gray-700 focus:outline-none focus:border-give-primary bg-white transition-all"
+        >
+          <option value="">All donors</option>
+          <option value="recurring">Recurring</option>
+          <option value="one_time">One-time</option>
+        </select>
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          title="From date"
+          className="px-3 py-2.5 rounded-lg border border-gray-200 text-sm text-gray-700 focus:outline-none focus:border-give-primary bg-white transition-all"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          title="To date"
+          className="px-3 py-2.5 rounded-lg border border-gray-200 text-sm text-gray-700 focus:outline-none focus:border-give-primary bg-white transition-all"
+        />
       </div>
 
-      {/* ── Error ────────────────────────────────────── */}
-      {donorsError && (
+      {/* ── Error ──────────────────────────────────────── */}
+      {error && (
         <div className="rounded-xl border border-red-100 bg-red-50 p-4 text-sm text-red-600">
-          Error loading donors: {donorsError}
+          {error}
         </div>
       )}
 
-      {/* ── Empty State ──────────────────────────────── */}
-      {hasNoDonors && (
-        <div className="bg-white rounded-xl border border-gray-100 px-6 py-16 text-center">
-          <p className="text-gray-900 font-semibold mb-1">No donors yet</p>
-          <p className="text-gray-500 text-sm">Share your campaign to start receiving donations.</p>
-        </div>
-      )}
-
-      {/* ── Table ────────────────────────────────────── */}
-      {(loading || donors.length > 0) && !donorsError && (
+      {/* ── Table ──────────────────────────────────────── */}
+      {!error && (
         <div className="bg-white rounded-xl border border-gray-100 overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-100 bg-gray-50/50">
-                  <th className="text-left py-3 px-6 font-medium text-gray-500">Donor</th>
-                  <th className="text-left py-3 px-4 font-medium text-gray-500">Email</th>
-                  <th className="text-right py-3 px-4 font-medium text-gray-500">Total Given</th>
-                  <th className="text-right py-3 px-4 font-medium text-gray-500">Donations</th>
-                  <th className="text-left py-3 px-4 font-medium text-gray-500">First Gift</th>
-                  <th className="text-left py-3 px-4 font-medium text-gray-500">Last Gift</th>
-                  <th className="text-left py-3 px-6 font-medium text-gray-500">Tags</th>
+                  <th className="text-left py-3 px-6 font-medium text-gray-500">
+                    Donor
+                  </th>
+                  <th className="text-left py-3 px-4 font-medium text-gray-500">
+                    Email
+                  </th>
+                  <SortHeader
+                    label="Total Given"
+                    field="totalGivenCents"
+                    currentSort={sortBy}
+                    currentOrder={sortOrder}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="Gifts"
+                    field="donationCount"
+                    currentSort={sortBy}
+                    currentOrder={sortOrder}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="First Gift"
+                    field="firstDonationAt"
+                    currentSort={sortBy}
+                    currentOrder={sortOrder}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    label="Last Gift"
+                    field="lastDonationAt"
+                    currentSort={sortBy}
+                    currentOrder={sortOrder}
+                    onSort={handleSort}
+                  />
+                  <th className="text-left py-3 px-6 font-medium text-gray-500">
+                    Tags
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-50">
-                {loading
-                  ? Array.from({ length: 5 }).map((_, i) => <DonorRowSkeleton key={i} />)
-                  : filtered.map((d) => (
-                      <tr key={d.id} className="hover:bg-gray-50/50 transition-colors">
+                {isLoading
+                  ? Array.from({ length: 6 }).map((_, i) => (
+                      <DonorRowSkeleton key={i} />
+                    ))
+                  : donors.map((d) => (
+                      <tr
+                        key={d.id}
+                        className="hover:bg-gray-50/60 transition-colors group cursor-pointer"
+                      >
                         <td className="py-4 px-6">
-                          <div className="flex items-center gap-3">
+                          <Link
+                            href={`/dashboard/donors/${d.id}`}
+                            className="flex items-center gap-3"
+                          >
                             <div className="w-8 h-8 rounded-full bg-give-primary/10 flex items-center justify-center text-xs font-bold text-give-primary flex-shrink-0">
-                              {d.firstName.charAt(0)}{d.lastName.charAt(0)}
+                              {d.firstName.charAt(0)}
+                              {d.lastName.charAt(0)}
                             </div>
-                            <span className="font-medium text-gray-900">{d.firstName} {d.lastName}</span>
-                          </div>
+                            <span className="font-medium text-gray-900 group-hover:text-give-primary transition-colors">
+                              {d.firstName} {d.lastName}
+                            </span>
+                          </Link>
                         </td>
                         <td className="py-4 px-4 text-gray-500">{d.email}</td>
-                        <td className="py-4 px-4 text-right font-semibold text-gray-900">{formatCurrency(d.totalGivenCents)}</td>
-                        <td className="py-4 px-4 text-right text-gray-600">{d.donationCount}</td>
-                        <td className="py-4 px-4 text-gray-400">{formatDate(d.firstDonationAt)}</td>
-                        <td className="py-4 px-4 text-gray-400">{formatDate(d.lastDonationAt)}</td>
+                        <td className="py-4 px-4 text-right font-semibold text-gray-900">
+                          {formatCurrency(d.totalGivenCents)}
+                        </td>
+                        <td className="py-4 px-4 text-right text-gray-600">
+                          {d.donationCount}
+                        </td>
+                        <td className="py-4 px-4 text-gray-400">
+                          {formatDate(d.firstDonationAt)}
+                        </td>
+                        <td className="py-4 px-4 text-gray-400">
+                          {formatDate(d.lastDonationAt)}
+                        </td>
                         <td className="py-4 px-6">
                           <div className="flex flex-wrap gap-1">
                             {d.tags.map((tag) => (
-                              <span key={tag} className="inline-flex text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">
+                              <span
+                                key={tag}
+                                className="inline-flex text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600"
+                              >
                                 {tag}
                               </span>
                             ))}
@@ -184,16 +381,51 @@ export default function DonorsPage() {
                         </td>
                       </tr>
                     ))}
-                {hasNoResults && (
+                {!isLoading && donors.length === 0 && (
                   <tr>
-                    <td colSpan={7} className="py-12 text-center text-gray-400">
-                      No donors match your search.
+                    <td colSpan={7} className="py-16 text-center">
+                      <p className="text-gray-500 text-sm font-medium">
+                        No donors found
+                      </p>
+                      <p className="text-gray-400 text-xs mt-1">
+                        Try adjusting your filters
+                      </p>
                     </td>
                   </tr>
                 )}
               </tbody>
             </table>
           </div>
+
+          {/* Pagination */}
+          {meta && meta.totalPages > 1 && (
+            <div className="flex items-center justify-between px-6 py-3 border-t border-gray-100 bg-gray-50/30">
+              <p className="text-sm text-gray-500">
+                {(meta.page - 1) * meta.limit + 1}&ndash;
+                {Math.min(meta.page * meta.limit, meta.total)} of{" "}
+                {meta.total.toLocaleString()}
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                  className="px-3 py-1.5 rounded-lg text-sm border border-gray-200 text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  Previous
+                </button>
+                <span className="text-sm text-gray-500">
+                  {meta.page} / {meta.totalPages}
+                </span>
+                <button
+                  disabled={page >= meta.totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                  className="px-3 py-1.5 rounded-lg text-sm border border-gray-200 text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -227,17 +227,64 @@ export function getDonation(id: string): Promise<DonationDetail> {
   return request<DonationDetail>(`/api/donations/${id}`);
 }
 
+export interface ListDonationsFilters {
+  campaignId?: string;
+  status?: string;
+  startDate?: string;
+  endDate?: string;
+  search?: string;
+  sortBy?: "createdAt" | "amountCents" | "status";
+  sortOrder?: "asc" | "desc";
+  page?: number;
+  limit?: number;
+}
+
+export interface DonationListItem {
+  id: string;
+  amountCents: number;
+  totalChargedCents: number;
+  currency: string;
+  frequency: string;
+  status: string;
+  paymentMethod: string | null;
+  coverFees: boolean;
+  createdAt: string;
+  donor: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    anonymous: boolean;
+  } | null;
+  campaign: {
+    id: string;
+    title: string;
+    slug: string;
+  } | null;
+}
+
+export interface DonationListResponse {
+  data: DonationListItem[];
+  pagination: { page: number; limit: number; total: number; totalPages: number };
+}
+
 /** Protected — org dashboard lists donations */
 export function listDonations(
   orgId: string,
-  token: TokenGetter,
-  opts?: { campaignId?: string; limit?: number; page?: number }
-): Promise<{ data: Donation[]; pagination: { page: number; limit: number; total: number; totalPages: number } }> {
+  token?: TokenGetter,
+  filters?: ListDonationsFilters
+): Promise<DonationListResponse> {
   const params = new URLSearchParams({ orgId });
-  if (opts?.campaignId) params.set("campaignId", opts.campaignId);
-  if (opts?.limit) params.set("limit", String(opts.limit));
-  if (opts?.page) params.set("page", String(opts.page));
-  return request<{ data: Donation[]; pagination: { page: number; limit: number; total: number; totalPages: number } }>(`/api/donations?${params}`, { token });
+  if (filters?.campaignId) params.set("campaignId", filters.campaignId);
+  if (filters?.status) params.set("status", filters.status);
+  if (filters?.startDate) params.set("startDate", filters.startDate);
+  if (filters?.endDate) params.set("endDate", filters.endDate);
+  if (filters?.search) params.set("search", filters.search);
+  if (filters?.sortBy) params.set("sortBy", filters.sortBy);
+  if (filters?.sortOrder) params.set("sortOrder", filters.sortOrder);
+  if (filters?.limit) params.set("limit", String(filters.limit));
+  if (filters?.page) params.set("page", String(filters.page));
+  return request<DonationListResponse>(`/api/donations?${params}`, token ? { token } : undefined);
 }
 
 // ─── Donor ───────────────────────────────────────────────
@@ -256,14 +303,56 @@ export interface Donor {
   createdAt: string;
 }
 
+export interface DonorListMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface DonorListParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  sortBy?: "totalGivenCents" | "lastDonationAt" | "donationCount" | "firstDonationAt";
+  sortOrder?: "asc" | "desc";
+  frequency?: "one_time" | "recurring";
+  startDate?: string;
+  endDate?: string;
+  campaignId?: string;
+}
+
 /** Protected — org dashboard */
 export function listDonors(
   orgId: string,
-  token: TokenGetter
-): Promise<Donor[]> {
-  return request<{ data: Donor[] }>(`/api/orgs/${orgId}/donors`, { token }).then(
-    (r) => r.data
-  );
+  token: TokenGetter,
+  params?: DonorListParams
+): Promise<{ data: Donor[]; meta: DonorListMeta }> {
+  const qp = new URLSearchParams({ orgId });
+  if (params?.page) qp.set("page", String(params.page));
+  if (params?.limit) qp.set("limit", String(params.limit));
+  if (params?.search) qp.set("search", params.search);
+  if (params?.sortBy) qp.set("sortBy", params.sortBy);
+  if (params?.sortOrder) qp.set("sortOrder", params.sortOrder);
+  if (params?.frequency) qp.set("frequency", params.frequency);
+  if (params?.startDate) qp.set("startDate", params.startDate);
+  if (params?.endDate) qp.set("endDate", params.endDate);
+  if (params?.campaignId) qp.set("campaignId", params.campaignId);
+  return request<{ data: Donor[]; meta: DonorListMeta }>(`/api/donors?${qp}`, { token });
+}
+
+/** Returns the CSV export URL for donors matching the given filters */
+export function exportDonorsCsvUrl(
+  orgId: string,
+  params?: Omit<DonorListParams, "page" | "limit" | "sortBy" | "sortOrder">
+): string {
+  const qp = new URLSearchParams({ orgId });
+  if (params?.search) qp.set("search", params.search);
+  if (params?.frequency) qp.set("frequency", params.frequency);
+  if (params?.startDate) qp.set("startDate", params.startDate);
+  if (params?.endDate) qp.set("endDate", params.endDate);
+  if (params?.campaignId) qp.set("campaignId", params.campaignId);
+  return `${BASE_URL}/api/donors/export?${qp}`;
 }
 
 // ─── Organization Stats ──────────────────────────────────


### PR DESCRIPTION
Closes #41

## Changes

### API
- `GET /api/donors` — enhanced with sort (`totalGivenCents`, `lastDonationAt`, `donationCount`, `firstDonationAt`), pagination, and filters: search by name/email, recurring vs one-time, date range, campaign
- `GET /api/donors/export` — CSV export with all active filters applied (cursor-based, up to 50k rows)
- `GET /api/donors/:id` — donor detail with paginated donation history and `avgGiftCents`

### Dashboard
- `/dashboard/donors` — full rebuild: sortable column headers, debounced search, frequency dropdown, date-range pickers, CSV export button, loading skeletons, server-side pagination
- `/dashboard/donors/[id]` — existing detail page already present; API now returns real data including `avgGiftCents` and donation history

### Web `api.ts`
- `DonorListMeta`, `DonorListParams` interfaces
- `listDonors(orgId, token, params?)` — updated signature with filter/sort/pagination params
- `exportDonorsCsvUrl(orgId, params?)` — returns the CSV download URL with current filters