### PR TITLE
feat: Recurring donation management (cancel, update amount)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,6 +13,7 @@ import { stripeRoutes } from "./routes/stripe.js";
 import { clerkWebhookRoutes } from "./routes/clerk-webhooks.js";
 import { clerkAuth, requireOrgAccess } from "./middleware/auth.js";
 import type { AuthVariables } from "./middleware/auth.js";
+import { publicRateLimit, authRateLimit } from "./middleware/rate-limit.js";
 import { internalError, logServerError } from "./lib/errors.js";
 
 const app = new Hono<{ Variables: AuthVariables }>();
@@ -33,7 +34,8 @@ app.use(
 // Health check
 app.route("/api/health", healthRoutes);
 
-// Stripe webhooks & connect — Stripe calls these directly, must stay public
+// Stripe webhooks & connect — exempt from rate limiting (Stripe IPs are trusted)
+// Must stay public; signature verification happens inside the route handler.
 app.route("/api/stripe", stripeRoutes);
 
 // Clerk webhooks — verified by svix signature, not Clerk JWT
@@ -60,12 +62,22 @@ app.use("/api/campaigns/:id", async (c, next) => {
   return clerkAuth(c, next);
 });
 
+// Rate limit campaign mutations (authenticated) and reads (public)
+app.use("/api/campaigns", async (c, next) => {
+  if (c.req.method === "POST") return authRateLimit(c, next);
+  return publicRateLimit(c, next);
+});
+app.use("/api/campaigns/:id", async (c, next) => {
+  if (c.req.method === "PATCH") return authRateLimit(c, next);
+  return publicRateLimit(c, next);
+});
+
 app.route("/api/campaigns", campaignRoutes);
 
 // ─── Donation Route Auth ───────────────────────────────────
 //
 // Public (no auth):
-//   POST /api/donations          — anonymous donor checkout
+//   POST /api/donations          — anonymous donor checkout (10 req/min per IP)
 //   GET  /api/donations/:id      — donation confirmation page
 //
 // Protected (Clerk JWT required):
@@ -75,6 +87,14 @@ app.use("/api/donations", async (c, next) => {
   if (c.req.method !== "GET") return next();
   return clerkAuth(c, next);
 });
+
+// Public POST (donation creation) — strict limit to mitigate card-testing attacks
+app.use("/api/donations", async (c, next) => {
+  if (c.req.method === "GET") return authRateLimit(c, next);
+  return publicRateLimit(c, next);
+});
+// Confirmation page GET by id — public, moderate limit
+app.use("/api/donations/:id", publicRateLimit);
 
 app.route("/api/donations", donationRoutes);
 
@@ -91,10 +111,16 @@ app.use("/api/orgs/:idOrSlug/:rest{.*}", async (c, next) => {
 });
 app.use("/api/orgs/:idOrSlug/:rest{.*}", requireOrgAccess("idOrSlug"));
 
+// All org routes are authenticated — apply auth rate limit
+app.use("/api/orgs/*", authRateLimit);
+app.use("/api/orgs", authRateLimit);
+
 app.route("/api/orgs", orgRoutes);
 
 // ─── Donor Route Auth ─────────────────────────────────────
 // Auth enforced within the route handler via clerkAuth middleware
+app.use("/api/donors/*", authRateLimit);
+app.use("/api/donors", authRateLimit);
 app.route("/api/donors", donorRoutes);
 
 // ─── 404 catch-all ────────────────────────────────────────

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,7 @@ import { donationRoutes } from "./routes/donations.js";
 import { donorRoutes } from "./routes/donors.js";
 import { stripeRoutes } from "./routes/stripe.js";
 import { clerkWebhookRoutes } from "./routes/clerk-webhooks.js";
+import { manageRoutes } from "./routes/manage.js";
 import { clerkAuth, requireOrgAccess } from "./middleware/auth.js";
 import type { AuthVariables } from "./middleware/auth.js";
 import { publicRateLimit, authRateLimit } from "./middleware/rate-limit.js";
@@ -37,6 +38,10 @@ app.route("/api/health", healthRoutes);
 // Stripe webhooks & connect — exempt from rate limiting (Stripe IPs are trusted)
 // Must stay public; signature verification happens inside the route handler.
 app.route("/api/stripe", stripeRoutes);
+
+// Donor self-service (token-authenticated, no Clerk required)
+app.use("/api/manage/*", publicRateLimit);
+app.route("/api/manage", manageRoutes);
 
 // Clerk webhooks — verified by svix signature, not Clerk JWT
 // Note: no clerkAuth middleware — Clerk calls this directly

--- a/apps/api/src/lib/manage-token.ts
+++ b/apps/api/src/lib/manage-token.ts
@@ -1,0 +1,40 @@
+import { createHmac } from "crypto";
+
+const SECRET = process.env.MANAGE_TOKEN_SECRET ?? "dev-manage-secret";
+
+/**
+ * Generate a signed management token for a donor self-service URL.
+ * Format: base64url(donorId:orgId).HMAC
+ */
+export function generateManageToken(donorId: string, orgId: string): string {
+  const payload = Buffer.from(`${donorId}:${orgId}`).toString("base64url");
+  const sig = createHmac("sha256", SECRET).update(payload).digest("base64url");
+  return `${payload}.${sig}`;
+}
+
+/**
+ * Validate and decode a management token.
+ * Returns { donorId, orgId } or null if invalid.
+ */
+export function verifyManageToken(
+  token: string
+): { donorId: string; orgId: string } | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+
+  const [payload, sig] = parts;
+  const expectedSig = createHmac("sha256", SECRET)
+    .update(payload)
+    .digest("base64url");
+
+  if (sig !== expectedSig) return null;
+
+  try {
+    const decoded = Buffer.from(payload, "base64url").toString("utf-8");
+    const [donorId, orgId] = decoded.split(":");
+    if (!donorId || !orgId) return null;
+    return { donorId, orgId };
+  } catch {
+    return null;
+  }
+}

--- a/apps/api/src/lib/stripe.ts
+++ b/apps/api/src/lib/stripe.ts
@@ -72,3 +72,150 @@ export async function createPaymentIntent(
     stripeAccount: stripeAccountId,
   });
 }
+
+/**
+ * Create a Stripe Customer on a connected account.
+ */
+export async function createStripeCustomer(
+  email: string,
+  name: string,
+  stripeAccountId: string,
+  metadata: Record<string, string>
+): Promise<Stripe.Customer> {
+  return stripe.customers.create(
+    { email, name, metadata },
+    { stripeAccount: stripeAccountId }
+  );
+}
+
+/**
+ * Create a Stripe Price (inline product) for a subscription on a connected account.
+ */
+export async function createSubscriptionPrice(
+  amountCents: number,
+  currency: string,
+  interval: "month" | "year" | "week",
+  stripeAccountId: string,
+  productName: string
+): Promise<Stripe.Price> {
+  return stripe.prices.create(
+    {
+      currency,
+      unit_amount: amountCents,
+      recurring: { interval },
+      product_data: { name: productName },
+    },
+    { stripeAccount: stripeAccountId }
+  );
+}
+
+/**
+ * Create a Stripe Subscription on a connected account.
+ * Returns the subscription with the latest invoice's payment intent expanded.
+ */
+export async function createSubscription(
+  customerId: string,
+  priceId: string,
+  applicationFeePercent: number,
+  stripeAccountId: string,
+  metadata: Record<string, string>
+): Promise<Stripe.Subscription> {
+  return stripe.subscriptions.create(
+    {
+      customer: customerId,
+      items: [{ price: priceId }],
+      application_fee_percent: applicationFeePercent,
+      payment_behavior: "default_incomplete",
+      payment_settings: {
+        save_default_payment_method: "on_subscription",
+      },
+      expand: ["latest_invoice.payment_intent"],
+      metadata,
+    },
+    { stripeAccount: stripeAccountId }
+  );
+}
+
+/**
+ * Cancel a Stripe Subscription immediately.
+ */
+export async function cancelSubscription(
+  subscriptionId: string,
+  stripeAccountId: string
+): Promise<Stripe.Subscription> {
+  return stripe.subscriptions.cancel(
+    subscriptionId,
+    {},
+    { stripeAccount: stripeAccountId }
+  );
+}
+
+/**
+ * Update the amount of a Stripe Subscription (replace the price item).
+ */
+export async function updateSubscriptionAmount(
+  subscriptionId: string,
+  newAmountCents: number,
+  currency: string,
+  interval: "month" | "year" | "week",
+  stripeAccountId: string,
+  productName: string
+): Promise<Stripe.Subscription> {
+  // Create a new price for the new amount
+  const newPrice = await createSubscriptionPrice(
+    newAmountCents,
+    currency,
+    interval,
+    stripeAccountId,
+    productName
+  );
+
+  // Get current subscription to find the item ID
+  const sub = await stripe.subscriptions.retrieve(
+    subscriptionId,
+    {},
+    { stripeAccount: stripeAccountId }
+  );
+
+  return stripe.subscriptions.update(
+    subscriptionId,
+    {
+      items: [
+        {
+          id: sub.items.data[0]?.id,
+          price: newPrice.id,
+        },
+      ],
+      proration_behavior: "create_prorations",
+    },
+    { stripeAccount: stripeAccountId }
+  );
+}
+
+/**
+ * Create a Stripe Billing Portal session for a customer.
+ */
+export async function createBillingPortalSession(
+  customerId: string,
+  returnUrl: string,
+  stripeAccountId: string
+): Promise<Stripe.BillingPortal.Session> {
+  return stripe.billingPortal.sessions.create(
+    {
+      customer: customerId,
+      return_url: returnUrl,
+    },
+    { stripeAccount: stripeAccountId }
+  );
+}
+
+/**
+ * Compute application_fee_percent from fixed fee cents and total amount cents.
+ */
+export function computeApplicationFeePercent(
+  platformFeeCents: number,
+  totalCents: number
+): number {
+  if (totalCents === 0) return 0;
+  return Math.round((platformFeeCents / totalCents) * 10000) / 100;
+}

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,0 +1,135 @@
+/**
+ * In-memory rate limiting middleware for Hono.
+ *
+ * Limits:
+ *   - Public endpoints:        10 req/min per IP
+ *   - Authenticated endpoints: 100 req/min per user ID
+ *   - Stripe webhook:          exempt
+ *
+ * Upgrade path: swap the `store` Map for a Redis client.
+ */
+
+import type { Context, MiddlewareHandler, Next } from "hono";
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number; // Unix ms
+}
+
+interface RateLimitOptions {
+  /** Max requests allowed in the window. */
+  limit: number;
+  /** Window duration in milliseconds. */
+  windowMs: number;
+  /**
+   * Derive the rate-limit key from the request context.
+   * Return `null` to skip rate limiting for this request.
+   */
+  keyFn: (c: Context) => string | null;
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+/** Purge expired entries to prevent unbounded memory growth. */
+function purgeExpired(): void {
+  const now = Date.now();
+  for (const [key, entry] of store.entries()) {
+    if (entry.resetAt <= now) {
+      store.delete(key);
+    }
+  }
+}
+
+// Purge every 5 minutes.
+setInterval(purgeExpired, 5 * 60 * 1_000).unref();
+
+function createRateLimiter(options: RateLimitOptions): MiddlewareHandler {
+  const { limit, windowMs } = options;
+
+  return async (c: Context, next: Next): Promise<Response | void> => {
+    const key = options.keyFn(c);
+
+    // null key → exempt from rate limiting
+    if (key === null) {
+      return next();
+    }
+
+    const now = Date.now();
+    let entry = store.get(key);
+
+    if (!entry || entry.resetAt <= now) {
+      entry = { count: 1, resetAt: now + windowMs };
+      store.set(key, entry);
+    } else {
+      entry.count += 1;
+    }
+
+    const remaining = Math.max(0, limit - entry.count);
+    const retryAfterSec = Math.ceil((entry.resetAt - now) / 1_000);
+
+    c.header("X-RateLimit-Limit", String(limit));
+    c.header("X-RateLimit-Remaining", String(remaining));
+    c.header("X-RateLimit-Reset", String(Math.ceil(entry.resetAt / 1_000)));
+
+    if (entry.count > limit) {
+      c.header("Retry-After", String(retryAfterSec));
+      return c.json(
+        {
+          error: {
+            code: "RATE_LIMIT_EXCEEDED",
+            message: "Too many requests. Please retry after the indicated time.",
+            details: { retryAfterSeconds: retryAfterSec },
+          },
+        },
+        429
+      );
+    }
+
+    return next();
+  };
+}
+
+/** Returns the best-effort client IP from common proxy headers. */
+function getClientIp(c: Context): string {
+  return (
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ??
+    c.req.header("x-real-ip") ??
+    "unknown"
+  );
+}
+
+/**
+ * Rate limiter for public endpoints (e.g. donation creation).
+ * 10 requests per minute per IP.
+ */
+export const publicRateLimit: MiddlewareHandler = createRateLimiter({
+  limit: 10,
+  windowMs: 60_000,
+  keyFn: (c) => `public:${getClientIp(c)}:${c.req.path}`,
+});
+
+/**
+ * Rate limiter for authenticated endpoints.
+ * 100 requests per minute per authenticated user ID.
+ * Falls back to IP if no user ID is available.
+ */
+export const authRateLimit: MiddlewareHandler = createRateLimiter({
+  limit: 100,
+  windowMs: 60_000,
+  keyFn: (c) => {
+    // AuthVariables set by clerkAuth middleware
+    const userId =
+      (c.get("userId" as never) as string | undefined) ?? getClientIp(c);
+    return `auth:${userId}:${c.req.path}`;
+  },
+});
+
+/**
+ * No-op sentinel — explicitly marks a route as exempt from rate limiting.
+ * Use on Stripe webhook routes.
+ */
+export const rateLimitExempt: MiddlewareHandler = createRateLimiter({
+  limit: Infinity,
+  windowMs: 60_000,
+  keyFn: () => null,
+});

--- a/apps/api/src/routes/donations.ts
+++ b/apps/api/src/routes/donations.ts
@@ -4,8 +4,15 @@ import { prisma } from "@give/db";
 import type { PlanTier as PrismaPlanTier } from "@give/db";
 import { calculateFees } from "../lib/fees.js";
 import { getApplicationFeeAmount } from "../lib/fees.js";
-import { createPaymentIntent } from "../lib/stripe.js";
+import {
+  createPaymentIntent,
+  createStripeCustomer,
+  createSubscriptionPrice,
+  createSubscription,
+  computeApplicationFeePercent,
+} from "../lib/stripe.js";
 import type { PlanTier, PaymentMethod } from "@give/shared";
+import { generateManageToken } from "../lib/manage-token.js";
 
 export const donationRoutes = new Hono();
 
@@ -55,6 +62,16 @@ const PAYMENT_METHOD_MAP = {
   apple_pay: "APPLE_PAY",
   google_pay: "GOOGLE_PAY",
 } as const;
+
+// Map donation frequency to Stripe interval
+const FREQUENCY_TO_INTERVAL: Record<
+  "monthly" | "quarterly" | "annual",
+  "month" | "year" | "week"
+> = {
+  monthly: "month",
+  quarterly: "month", // Stripe doesn't support quarterly natively — we use monthly x3 workaround
+  annual: "year",
+};
 
 function planTierToShared(tier: PrismaPlanTier): PlanTier {
   return tier === "PRO" ? "pro" : "basic";
@@ -132,67 +149,184 @@ donationRoutes.post("/", async (c) => {
       },
     });
 
-    // Create donation record
-    const donation = await prisma.donation.create({
-      data: {
-        amountCents: fees.donationAmount,
-        currency: input.currency,
-        status: "PENDING",
-        frequency: FREQUENCY_MAP[input.frequency],
-        paymentMethod: PAYMENT_METHOD_MAP[input.paymentMethod],
-        processingFeeCents: fees.processingFee,
-        platformFeeCents: fees.platformFee,
-        netAmountCents: fees.netToOrg,
-        coverFees: input.coverFees,
-        totalChargedCents: fees.totalCharged,
-        dedicationType: input.dedication?.type ?? null,
-        dedicationName: input.dedication?.name ?? null,
-        dedicationMessage: input.dedication?.message ?? null,
-        donorId: donor.id,
-        campaignId: campaign.id,
-        orgId: org.id,
-      },
-    });
+    const isRecurring = input.frequency !== "one_time";
 
-    // Create Stripe PaymentIntent on the connected account
-    const applicationFee = getApplicationFeeAmount(fees.platformFee);
+    if (isRecurring) {
+      // ── Recurring: Stripe Subscription ──────────────────
 
-    const paymentIntent = await createPaymentIntent(
-      fees.totalCharged,
-      applicationFee,
-      org.stripeAccountId,
-      {
-        donationId: donation.id,
-        campaignId: campaign.id,
-        orgId: org.id,
-        donorId: donor.id,
-      }
-    );
+      const interval =
+        FREQUENCY_TO_INTERVAL[
+          input.frequency as "monthly" | "quarterly" | "annual"
+        ];
 
-    // Update donation with Stripe PaymentIntent ID
-    await prisma.donation.update({
-      where: { id: donation.id },
-      data: {
-        stripePaymentIntentId: paymentIntent.id,
-        status: "PROCESSING",
-      },
-    });
+      // For quarterly, use 3-month interval_count
+      const intervalCount = input.frequency === "quarterly" ? 3 : 1;
 
-    return c.json(
-      {
-        donationId: donation.id,
-        clientSecret: paymentIntent.client_secret,
-        stripeAccountId: org.stripeAccountId,
-        fees: {
-          donationAmount: fees.donationAmount,
-          processingFee: fees.processingFee,
-          platformFee: fees.platformFee,
-          totalCharged: fees.totalCharged,
-          netToOrg: fees.netToOrg,
+      // Create or reuse a Stripe customer on the connected account
+      const stripeCustomer = await createStripeCustomer(
+        donor.email,
+        `${donor.firstName} ${donor.lastName}`,
+        org.stripeAccountId,
+        {
+          donorId: donor.id,
+          orgId: org.id,
+        }
+      );
+
+      // Create a price for this amount + interval
+      const price = await createStripeSubscriptionPrice(
+        fees.totalCharged,
+        input.currency,
+        interval,
+        intervalCount,
+        org.stripeAccountId,
+        `${campaign.title} — ${input.frequency} donation`
+      );
+
+      // Application fee percent for Connect
+      const appFeePercent = computeApplicationFeePercent(
+        fees.platformFee,
+        fees.totalCharged
+      );
+
+      // Create donation record first (PENDING)
+      const donation = await prisma.donation.create({
+        data: {
+          amountCents: fees.donationAmount,
+          currency: input.currency,
+          status: "PENDING",
+          frequency: FREQUENCY_MAP[input.frequency],
+          paymentMethod: PAYMENT_METHOD_MAP[input.paymentMethod],
+          processingFeeCents: fees.processingFee,
+          platformFeeCents: fees.platformFee,
+          netAmountCents: fees.netToOrg,
+          coverFees: input.coverFees,
+          totalChargedCents: fees.totalCharged,
+          dedicationType: input.dedication?.type ?? null,
+          dedicationName: input.dedication?.name ?? null,
+          dedicationMessage: input.dedication?.message ?? null,
+          donorId: donor.id,
+          campaignId: campaign.id,
+          orgId: org.id,
+          stripeCustomerId: stripeCustomer.id,
         },
-      },
-      201
-    );
+      });
+
+      // Create Stripe Subscription
+      const subscription = await createSubscription(
+        stripeCustomer.id,
+        price.id,
+        appFeePercent,
+        org.stripeAccountId,
+        {
+          donationId: donation.id,
+          campaignId: campaign.id,
+          orgId: org.id,
+          donorId: donor.id,
+        }
+      );
+
+      // Extract PaymentIntent client_secret from the latest invoice
+      const latestInvoice = subscription.latest_invoice as
+        | { payment_intent?: { client_secret?: string | null } }
+        | null;
+      const clientSecret =
+        latestInvoice?.payment_intent?.client_secret ?? null;
+
+      // Update donation with subscription ID
+      await prisma.donation.update({
+        where: { id: donation.id },
+        data: {
+          stripeSubscriptionId: subscription.id,
+          status: "PROCESSING",
+        },
+      });
+
+      // Generate management token for self-service portal link
+      // TODO: include this token in receipt email (Resend integration pending)
+      const manageToken = generateManageToken(donor.id, org.id);
+      const baseUrl = process.env.APP_URL ?? "http://localhost:3000";
+      const manageUrl = `${baseUrl}/manage/${manageToken}`;
+
+      return c.json(
+        {
+          donationId: donation.id,
+          clientSecret,
+          stripeAccountId: org.stripeAccountId,
+          subscriptionId: subscription.id,
+          manageUrl,
+          fees: {
+            donationAmount: fees.donationAmount,
+            processingFee: fees.processingFee,
+            platformFee: fees.platformFee,
+            totalCharged: fees.totalCharged,
+            netToOrg: fees.netToOrg,
+          },
+        },
+        201
+      );
+    } else {
+      // ── One-time: Stripe PaymentIntent ───────────────────
+
+      const donation = await prisma.donation.create({
+        data: {
+          amountCents: fees.donationAmount,
+          currency: input.currency,
+          status: "PENDING",
+          frequency: FREQUENCY_MAP[input.frequency],
+          paymentMethod: PAYMENT_METHOD_MAP[input.paymentMethod],
+          processingFeeCents: fees.processingFee,
+          platformFeeCents: fees.platformFee,
+          netAmountCents: fees.netToOrg,
+          coverFees: input.coverFees,
+          totalChargedCents: fees.totalCharged,
+          dedicationType: input.dedication?.type ?? null,
+          dedicationName: input.dedication?.name ?? null,
+          dedicationMessage: input.dedication?.message ?? null,
+          donorId: donor.id,
+          campaignId: campaign.id,
+          orgId: org.id,
+        },
+      });
+
+      const applicationFee = getApplicationFeeAmount(fees.platformFee);
+
+      const paymentIntent = await createPaymentIntent(
+        fees.totalCharged,
+        applicationFee,
+        org.stripeAccountId,
+        {
+          donationId: donation.id,
+          campaignId: campaign.id,
+          orgId: org.id,
+          donorId: donor.id,
+        }
+      );
+
+      await prisma.donation.update({
+        where: { id: donation.id },
+        data: {
+          stripePaymentIntentId: paymentIntent.id,
+          status: "PROCESSING",
+        },
+      });
+
+      return c.json(
+        {
+          donationId: donation.id,
+          clientSecret: paymentIntent.client_secret,
+          stripeAccountId: org.stripeAccountId,
+          fees: {
+            donationAmount: fees.donationAmount,
+            processingFee: fees.processingFee,
+            platformFee: fees.platformFee,
+            totalCharged: fees.totalCharged,
+            netToOrg: fees.netToOrg,
+          },
+        },
+        201
+      );
+    }
   } catch (err) {
     console.error("Error creating donation:", err);
     return c.json({ error: "Failed to create donation" }, 500);
@@ -313,3 +447,94 @@ donationRoutes.get("/", async (c) => {
     return c.json({ error: "Failed to list donations" }, 500);
   }
 });
+
+// ─── GET /recurring — Recurring donors & MRR metrics ─────
+
+donationRoutes.get("/recurring/metrics", async (c) => {
+  const orgId = c.req.query("orgId");
+  if (!orgId) {
+    return c.json({ error: "orgId is required" }, 400);
+  }
+
+  try {
+    // All active recurring donations (unique subscriptions)
+    const recurringDonations = await prisma.donation.findMany({
+      where: {
+        orgId,
+        stripeSubscriptionId: { not: null },
+        frequency: { not: "ONE_TIME" },
+        status: "SUCCEEDED",
+      },
+      distinct: ["stripeSubscriptionId"],
+      include: {
+        donor: {
+          select: {
+            id: true,
+            firstName: true,
+            lastName: true,
+            email: true,
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    // MRR: normalize all frequencies to monthly equivalent
+    const mrrCents = recurringDonations.reduce((sum, d) => {
+      switch (d.frequency) {
+        case "MONTHLY":
+          return sum + d.amountCents;
+        case "QUARTERLY":
+          return sum + Math.round(d.amountCents / 3);
+        case "ANNUAL":
+          return sum + Math.round(d.amountCents / 12);
+        default:
+          return sum;
+      }
+    }, 0);
+
+    // Failed/churned subscriptions in last 30 days
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const churnedCount = await prisma.donation.count({
+      where: {
+        orgId,
+        stripeSubscriptionId: { not: null },
+        status: "FAILED",
+        updatedAt: { gte: thirtyDaysAgo },
+      },
+    });
+
+    return c.json({
+      recurringDonors: recurringDonations.length,
+      mrrCents,
+      churnedLast30Days: churnedCount,
+      donors: recurringDonations,
+    });
+  } catch (err) {
+    console.error("Error fetching recurring metrics:", err);
+    return c.json({ error: "Failed to fetch recurring metrics" }, 500);
+  }
+});
+
+// ─── Helpers ──────────────────────────────────────────────
+
+// Wrapper to support quarterly (interval_count=3) via stripe.prices.create
+async function createStripeSubscriptionPrice(
+  amountCents: number,
+  currency: string,
+  interval: "month" | "year" | "week",
+  intervalCount: number,
+  stripeAccountId: string,
+  productName: string
+) {
+  const { stripe } = await import("../lib/stripe.js");
+  return stripe.prices.create(
+    {
+      currency,
+      unit_amount: amountCents,
+      recurring: { interval, interval_count: intervalCount },
+      product_data: { name: productName },
+    },
+    { stripeAccount: stripeAccountId }
+  );
+}

--- a/apps/api/src/routes/donors.ts
+++ b/apps/api/src/routes/donors.ts
@@ -6,7 +6,7 @@ import type { AuthVariables } from "../middleware/auth.js";
 
 export const donorRoutes = new Hono<{ Variables: AuthVariables }>();
 
-// ─── Validation Schemas ───────────────────────────────────
+// ── Validation Schemas ────────────────────────────────────
 
 const listDonorsSchema = z.object({
   orgId: z.string().min(1),
@@ -14,20 +14,31 @@ const listDonorsSchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(20),
   search: z.string().optional(),
   tag: z.string().optional(),
+  campaignId: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  frequency: z.enum(["one_time", "recurring"]).optional(),
+  sortBy: z
+    .enum(["totalGivenCents", "lastDonationAt", "donationCount", "firstDonationAt", "createdAt"])
+    .default("lastDonationAt"),
+  sortOrder: z.enum(["asc", "desc"]).default("desc"),
 });
 
 const exportDonorsSchema = z.object({
   orgId: z.string().min(1),
   search: z.string().optional(),
   tag: z.string().optional(),
+  campaignId: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  frequency: z.enum(["one_time", "recurring"]).optional(),
 });
 
-// ─── Helper: escape CSV field ─────────────────────────────
+// ── CSV helpers ───────────────────────────────────────────
 
 function csvField(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return "";
   const str = String(value);
-  // Wrap in quotes if contains comma, quote, or newline
   if (str.includes(",") || str.includes('"') || str.includes("\n")) {
     return `"${str.replace(/"/g, '""')}"`;
   }
@@ -40,10 +51,56 @@ function buildCsvRow(fields: (string | number | null | undefined)[]): string {
 
 function formatDateYMD(date: Date | null | undefined): string {
   if (!date) return "";
-  return date.toISOString().slice(0, 10); // YYYY-MM-DD
+  return date.toISOString().slice(0, 10);
 }
 
-// ─── GET / — List Donors for Org ─────────────────────────
+// ── Build where clause ────────────────────────────────────
+
+function buildDonorWhere(params: {
+  orgId: string;
+  search?: string;
+  tag?: string;
+  campaignId?: string;
+  startDate?: string;
+  endDate?: string;
+  frequency?: "one_time" | "recurring";
+}): Prisma.DonorWhereInput {
+  const { orgId, search, tag, campaignId, startDate, endDate, frequency } = params;
+  const where: Prisma.DonorWhereInput = { orgId };
+
+  if (search) {
+    where.OR = [
+      { firstName: { contains: search, mode: "insensitive" } },
+      { lastName: { contains: search, mode: "insensitive" } },
+      { email: { contains: search, mode: "insensitive" } },
+    ];
+  }
+
+  if (tag) {
+    where.tags = { some: { name: { equals: tag, mode: "insensitive" } } };
+  }
+
+  if (campaignId || startDate || endDate || frequency) {
+    const donationsFilter: Prisma.DonationWhereInput = {};
+    if (campaignId) donationsFilter.campaignId = campaignId;
+    if (startDate || endDate) {
+      const dateFilter: Prisma.DateTimeFilter = {};
+      if (startDate) dateFilter.gte = new Date(startDate);
+      if (endDate) dateFilter.lte = new Date(endDate);
+      donationsFilter.createdAt = dateFilter;
+    }
+    if (frequency === "recurring") {
+      donationsFilter.frequency = { not: "ONE_TIME" };
+    } else if (frequency === "one_time") {
+      donationsFilter.frequency = "ONE_TIME";
+    }
+    where.donations = { some: donationsFilter };
+  }
+
+  return where;
+}
+
+// ── GET / — List Donors ───────────────────────────────────
 
 donorRoutes.get("/", requireOrgAccess("orgId"), async (c) => {
   const query = listDonorsSchema.safeParse({
@@ -52,40 +109,28 @@ donorRoutes.get("/", requireOrgAccess("orgId"), async (c) => {
     limit: c.req.query("limit"),
     search: c.req.query("search"),
     tag: c.req.query("tag"),
+    campaignId: c.req.query("campaignId"),
+    startDate: c.req.query("startDate"),
+    endDate: c.req.query("endDate"),
+    frequency: c.req.query("frequency"),
+    sortBy: c.req.query("sortBy"),
+    sortOrder: c.req.query("sortOrder"),
   });
 
   if (!query.success) {
-    return c.json(
-      { error: "Validation failed", details: query.error.flatten() },
-      400
-    );
+    return c.json({ error: "Validation failed", details: query.error.flatten() }, 400);
   }
 
-  const { orgId, page, limit, search, tag } = query.data;
+  const { orgId, page, limit, sortBy, sortOrder, ...filters } = query.data;
   const skip = (page - 1) * limit;
-
-  const where: Prisma.DonorWhereInput = {
-    orgId,
-    ...(search
-      ? {
-          OR: [
-            { firstName: { contains: search, mode: "insensitive" } },
-            { lastName: { contains: search, mode: "insensitive" } },
-            { email: { contains: search, mode: "insensitive" } },
-          ],
-        }
-      : {}),
-    ...(tag ? { tags: { some: { name: { equals: tag, mode: "insensitive" } } } } : {}),
-  };
+  const where = buildDonorWhere({ orgId, ...filters });
 
   try {
     const [donors, total] = await Promise.all([
       prisma.donor.findMany({
         where,
-        include: {
-          tags: { select: { name: true } },
-        },
-        orderBy: { lastDonationAt: "desc" },
+        include: { tags: { select: { name: true } } },
+        orderBy: { [sortBy]: sortOrder },
         skip,
         take: limit,
       }),
@@ -94,12 +139,7 @@ donorRoutes.get("/", requireOrgAccess("orgId"), async (c) => {
 
     return c.json({
       data: donors,
-      pagination: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit),
-      },
+      meta: { page, limit, total, totalPages: Math.ceil(total / limit) },
     });
   } catch (err) {
     console.error("Error listing donors:", err);
@@ -107,65 +147,38 @@ donorRoutes.get("/", requireOrgAccess("orgId"), async (c) => {
   }
 });
 
-// ─── GET /export — Export Donors as CSV ──────────────────
+// ── GET /export — CSV Export ──────────────────────────────
 
 donorRoutes.get("/export", requireOrgAccess("orgId"), async (c) => {
   const query = exportDonorsSchema.safeParse({
     orgId: c.req.query("orgId"),
     search: c.req.query("search"),
     tag: c.req.query("tag"),
+    campaignId: c.req.query("campaignId"),
+    startDate: c.req.query("startDate"),
+    endDate: c.req.query("endDate"),
+    frequency: c.req.query("frequency"),
   });
 
   if (!query.success) {
-    return c.json(
-      { error: "Validation failed", details: query.error.flatten() },
-      400
-    );
+    return c.json({ error: "Validation failed", details: query.error.flatten() }, 400);
   }
 
-  const { orgId, search, tag } = query.data;
-
-  const where: Prisma.DonorWhereInput = {
-    orgId,
-    ...(search
-      ? {
-          OR: [
-            { firstName: { contains: search, mode: "insensitive" } },
-            { lastName: { contains: search, mode: "insensitive" } },
-            { email: { contains: search, mode: "insensitive" } },
-          ],
-        }
-      : {}),
-    ...(tag ? { tags: { some: { name: { equals: tag, mode: "insensitive" } } } } : {}),
-  };
+  const { orgId, ...filters } = query.data;
+  const where = buildDonorWhere({ orgId, ...filters });
 
   try {
-    // Fetch org slug for filename
     const org = await prisma.organization.findUnique({
       where: { id: orgId },
       select: { slug: true },
     });
 
-    if (!org) {
-      return c.json({ error: "Organization not found" }, 404);
-    }
+    if (!org) return c.json({ error: "Organization not found" }, 404);
 
     const EXPORT_LIMIT = 50_000;
-
-    // Use cursor-based pagination for large datasets
-    const rows: string[] = [];
-    const header = buildCsvRow([
-      "First Name",
-      "Last Name",
-      "Email",
-      "Phone",
-      "Total Given",
-      "Donation Count",
-      "First Donation",
-      "Last Donation",
-      "Tags",
-    ]);
-    rows.push(header);
+    const rows: string[] = [
+      buildCsvRow(["First Name","Last Name","Email","Phone","Total Given","Donation Count","First Donation","Last Donation","Tags"]),
+    ];
 
     let cursor: string | undefined;
     let totalExported = 0;
@@ -183,38 +196,22 @@ donorRoutes.get("/export", requireOrgAccess("orgId"), async (c) => {
       if (batch.length === 0) break;
 
       for (const donor of batch) {
-        rows.push(
-          buildCsvRow([
-            donor.firstName,
-            donor.lastName,
-            donor.email,
-            donor.phone ?? "",
-            (donor.totalGivenCents / 100).toFixed(2),
-            donor.donationCount,
-            formatDateYMD(donor.firstDonationAt),
-            formatDateYMD(donor.lastDonationAt),
-            donor.tags.map((t) => t.name).join("; "),
-          ])
-        );
+        rows.push(buildCsvRow([
+          donor.firstName, donor.lastName, donor.email, donor.phone ?? "",
+          (donor.totalGivenCents / 100).toFixed(2), donor.donationCount,
+          formatDateYMD(donor.firstDonationAt), formatDateYMD(donor.lastDonationAt),
+          donor.tags.map((t) => t.name).join("; "),
+        ]));
       }
 
       totalExported += batch.length;
       cursor = batch[batch.length - 1].id;
-
-      if (totalExported >= EXPORT_LIMIT) {
-        truncated = true;
-        break;
-      }
-
+      if (totalExported >= EXPORT_LIMIT) { truncated = true; break; }
       if (batch.length < 1000) break;
     }
 
     if (truncated) {
-      rows.push(
-        buildCsvRow([
-          `[Export truncated at ${EXPORT_LIMIT} rows. Please apply filters to export smaller batches.]`,
-        ])
-      );
+      rows.push(buildCsvRow([`[Export truncated at ${EXPORT_LIMIT} rows. Apply filters to export smaller batches.]`]));
     }
 
     const csv = rows.join("\r\n");
@@ -231,5 +228,48 @@ donorRoutes.get("/export", requireOrgAccess("orgId"), async (c) => {
   } catch (err) {
     console.error("Error exporting donors:", err);
     return c.json({ error: "Failed to export donors" }, 500);
+  }
+});
+
+// ── GET /:id — Donor Detail + Donation History ────────────
+
+donorRoutes.get("/:id", requireOrgAccess("orgId"), async (c) => {
+  const { id } = c.req.param();
+  const orgId = c.req.query("orgId") ?? "";
+  const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10));
+  const limit = Math.min(50, Math.max(1, parseInt(c.req.query("limit") ?? "20", 10)));
+
+  try {
+    const donor = await prisma.donor.findUnique({
+      where: { id },
+      include: { tags: { select: { id: true, name: true } } },
+    });
+
+    if (!donor || donor.orgId !== orgId) {
+      return c.json({ error: "Donor not found" }, 404);
+    }
+
+    const [donations, donationTotal] = await Promise.all([
+      prisma.donation.findMany({
+        where: { donorId: id, orgId },
+        include: { campaign: { select: { id: true, title: true, slug: true } } },
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * limit,
+        take: limit,
+      }),
+      prisma.donation.count({ where: { donorId: id, orgId } }),
+    ]);
+
+    const avgGiftCents = donor.donationCount > 0
+      ? Math.round(donor.totalGivenCents / donor.donationCount)
+      : 0;
+
+    return c.json({
+      data: { donor: { ...donor, avgGiftCents }, donations },
+      meta: { page, limit, total: donationTotal, totalPages: Math.ceil(donationTotal / limit) },
+    });
+  } catch (err) {
+    console.error("Error fetching donor:", err);
+    return c.json({ error: "Failed to fetch donor" }, 500);
   }
 });

--- a/apps/api/src/routes/manage.ts
+++ b/apps/api/src/routes/manage.ts
@@ -1,0 +1,251 @@
+import { Hono } from "hono";
+import { z } from "zod";
+import { prisma } from "@give/db";
+import { verifyManageToken } from "../lib/manage-token.js";
+import {
+  cancelSubscription,
+  updateSubscriptionAmount,
+  createBillingPortalSession,
+} from "../lib/stripe.js";
+
+export const manageRoutes = new Hono();
+
+// ─── GET /:token — Get donor subscriptions ────────────────
+
+manageRoutes.get("/:token", async (c) => {
+  const token = c.req.param("token");
+  const decoded = verifyManageToken(token);
+
+  if (!decoded) {
+    return c.json({ error: "Invalid or expired management link" }, 401);
+  }
+
+  const { donorId, orgId } = decoded;
+
+  try {
+    const donor = await prisma.donor.findUnique({
+      where: { id: donorId },
+      select: {
+        id: true,
+        firstName: true,
+        lastName: true,
+        email: true,
+        donations: {
+          where: {
+            orgId,
+            stripeSubscriptionId: { not: null },
+            frequency: { not: "ONE_TIME" },
+          },
+          distinct: ["stripeSubscriptionId"],
+          orderBy: { createdAt: "desc" },
+          include: {
+            campaign: {
+              select: { id: true, title: true, slug: true },
+            },
+            org: {
+              select: { id: true, name: true, logoUrl: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!donor) {
+      return c.json({ error: "Donor not found" }, 404);
+    }
+
+    return c.json({
+      donor: {
+        id: donor.id,
+        firstName: donor.firstName,
+        lastName: donor.lastName,
+        email: donor.email,
+      },
+      subscriptions: donor.donations.map((d) => ({
+        donationId: d.id,
+        subscriptionId: d.stripeSubscriptionId,
+        amountCents: d.amountCents,
+        frequency: d.frequency,
+        status: d.status,
+        campaign: d.campaign,
+        org: d.org,
+        createdAt: d.createdAt,
+      })),
+    });
+  } catch (err) {
+    console.error("Error fetching donor subscriptions:", err);
+    return c.json({ error: "Failed to fetch subscriptions" }, 500);
+  }
+});
+
+// ─── POST /:token/portal — Create Stripe Billing Portal session ──
+
+manageRoutes.post("/:token/portal", async (c) => {
+  const token = c.req.param("token");
+  const decoded = verifyManageToken(token);
+
+  if (!decoded) {
+    return c.json({ error: "Invalid or expired management link" }, 401);
+  }
+
+  const { donorId, orgId } = decoded;
+
+  try {
+    // Find a recent donation to get the stripeCustomerId and stripeAccountId
+    const donation = await prisma.donation.findFirst({
+      where: {
+        donorId,
+        orgId,
+        stripeCustomerId: { not: null },
+      },
+      include: {
+        org: { select: { stripeAccountId: true } },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    if (!donation?.stripeCustomerId || !donation.org.stripeAccountId) {
+      return c.json({ error: "No billing data found for this donor" }, 404);
+    }
+
+    const baseUrl = process.env.APP_URL ?? "http://localhost:3000";
+    const session = await createBillingPortalSession(
+      donation.stripeCustomerId,
+      `${baseUrl}/manage/${token}`,
+      donation.org.stripeAccountId
+    );
+
+    return c.json({ portalUrl: session.url });
+  } catch (err) {
+    console.error("Error creating billing portal session:", err);
+    return c.json({ error: "Failed to create portal session" }, 500);
+  }
+});
+
+// ─── POST /:token/cancel — Cancel a subscription ──────────
+
+const cancelSchema = z.object({ subscriptionId: z.string().min(1) });
+
+manageRoutes.post("/:token/cancel", async (c) => {
+  const token = c.req.param("token");
+  const decoded = verifyManageToken(token);
+
+  if (!decoded) {
+    return c.json({ error: "Invalid or expired management link" }, 401);
+  }
+
+  const { donorId, orgId } = decoded;
+
+  const body = await c.req.json().catch(() => null);
+  const parsed = cancelSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json({ error: "subscriptionId is required" }, 400);
+  }
+
+  const { subscriptionId } = parsed.data;
+
+  try {
+    // Verify the subscription belongs to this donor/org
+    const donation = await prisma.donation.findFirst({
+      where: { donorId, orgId, stripeSubscriptionId: subscriptionId },
+      include: { org: { select: { stripeAccountId: true } } },
+    });
+
+    if (!donation) {
+      return c.json({ error: "Subscription not found" }, 404);
+    }
+
+    if (!donation.org.stripeAccountId) {
+      return c.json({ error: "Organization payment setup incomplete" }, 400);
+    }
+
+    await cancelSubscription(subscriptionId, donation.org.stripeAccountId);
+
+    // Update donation status in DB (webhook will also fire, but update optimistically)
+    await prisma.donation.updateMany({
+      where: { orgId, stripeSubscriptionId: subscriptionId },
+      data: { status: "FAILED" },
+    });
+
+    return c.json({ success: true, message: "Subscription cancelled" });
+  } catch (err) {
+    console.error("Error cancelling subscription:", err);
+    return c.json({ error: "Failed to cancel subscription" }, 500);
+  }
+});
+
+// ─── POST /:token/update-amount — Update subscription amount ─
+
+const updateAmountSchema = z.object({
+  subscriptionId: z.string().min(1),
+  newAmountCents: z.number().int().positive().min(100),
+});
+
+manageRoutes.post("/:token/update-amount", async (c) => {
+  const token = c.req.param("token");
+  const decoded = verifyManageToken(token);
+
+  if (!decoded) {
+    return c.json({ error: "Invalid or expired management link" }, 401);
+  }
+
+  const { donorId, orgId } = decoded;
+
+  const body = await c.req.json().catch(() => null);
+  const parsed = updateAmountSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      400
+    );
+  }
+
+  const { subscriptionId, newAmountCents } = parsed.data;
+
+  try {
+    const donation = await prisma.donation.findFirst({
+      where: { donorId, orgId, stripeSubscriptionId: subscriptionId },
+      include: {
+        org: { select: { stripeAccountId: true, name: true } },
+        campaign: { select: { title: true } },
+      },
+    });
+
+    if (!donation) {
+      return c.json({ error: "Subscription not found" }, 404);
+    }
+
+    if (!donation.org.stripeAccountId) {
+      return c.json({ error: "Organization payment setup incomplete" }, 400);
+    }
+
+    const interval =
+      donation.frequency === "ANNUAL"
+        ? "year"
+        : "month";
+
+    await updateSubscriptionAmount(
+      subscriptionId,
+      newAmountCents,
+      donation.currency,
+      interval,
+      donation.org.stripeAccountId,
+      `${donation.campaign.title} — donation`
+    );
+
+    // Update local donation record amount
+    await prisma.donation.update({
+      where: { id: donation.id },
+      data: { amountCents: newAmountCents },
+    });
+
+    return c.json({
+      success: true,
+      message: "Subscription amount updated",
+      newAmountCents,
+    });
+  } catch (err) {
+    console.error("Error updating subscription amount:", err);
+    return c.json({ error: "Failed to update subscription amount" }, 500);
+  }
+});

--- a/apps/api/src/routes/stripe.ts
+++ b/apps/api/src/routes/stripe.ts
@@ -26,8 +26,6 @@ import { normalizeEmail } from "../lib/sanitize.js";
 export const stripeRoutes = new Hono();
 
 // ─── In-memory processed event IDs (idempotency) ─────────
-// Prevents double-processing if Stripe retries a webhook event.
-// MVP: in-memory set. For multi-instance, move to Redis or DB.
 const processedEventIds = new Set<string>();
 
 // ─── Validation Schemas ───────────────────────────────────
@@ -46,7 +44,6 @@ stripeRoutes.post("/connect", async (c) => {
     return c.json(err, 400);
   }
 
-  // Sanitize
   if (typeof body.email === "string") body.email = normalizeEmail(body.email);
 
   const parsed = connectSchema.safeParse(body);
@@ -67,7 +64,6 @@ stripeRoutes.post("/connect", async (c) => {
       return c.json(err, 404);
     }
 
-    // If org already has a Stripe account, just generate a new onboarding link
     if (org.stripeAccountId) {
       const baseUrl = process.env.APP_URL ?? "http://localhost:3000";
       const accountLink = await createAccountLink(
@@ -83,16 +79,13 @@ stripeRoutes.post("/connect", async (c) => {
       });
     }
 
-    // Create new Stripe Connect account
     const stripeAccount = await createConnectAccount(org.name, email);
 
-    // Save Stripe account ID to org
     await prisma.organization.update({
       where: { id: orgId },
       data: { stripeAccountId: stripeAccount.id },
     });
 
-    // Generate onboarding link
     const baseUrl = process.env.APP_URL ?? "http://localhost:3000";
     const accountLink = await createAccountLink(
       stripeAccount.id,
@@ -160,10 +153,6 @@ stripeRoutes.get("/connect/refresh/:orgId", async (c) => {
 });
 
 // ─── POST /webhooks — Stripe Webhook Handler ──────────────
-// Resilience rules:
-//  1. Always return 200 after successful signature verification — never 5xx
-//  2. Catch errors per-event so one bad event doesn't block others
-//  3. Skip already-processed event IDs (idempotency)
 
 stripeRoutes.post("/webhooks", async (c) => {
   const signature = c.req.header("stripe-signature");
@@ -192,7 +181,6 @@ stripeRoutes.post("/webhooks", async (c) => {
   let event: Stripe.Event;
 
   try {
-    // Hono gives us the raw body for webhook signature verification
     const rawBody = await c.req.text();
     event = stripe.webhooks.constructEvent(rawBody, signature, webhookSecret);
   } catch (err) {
@@ -207,13 +195,11 @@ stripeRoutes.post("/webhooks", async (c) => {
     return c.json(body, 400);
   }
 
-  // Idempotency: skip already-processed events
   if (processedEventIds.has(event.id)) {
     console.log(`Stripe webhook: skipping already-processed event ${event.id}`);
     return c.json({ received: true, skipped: true });
   }
 
-  // Dispatch — catch per-event errors so we always return 200
   try {
     switch (event.type) {
       case "payment_intent.succeeded":
@@ -232,12 +218,26 @@ stripeRoutes.post("/webhooks", async (c) => {
         await handleAccountUpdated(event.data.object as Stripe.Account);
         break;
 
+      // ── Subscription / Invoice events ────────────────────
+
+      case "invoice.paid":
+        await handleInvoicePaid(event.data.object as Stripe.Invoice);
+        break;
+
+      case "invoice.payment_failed":
+        await handleInvoicePaymentFailed(event.data.object as Stripe.Invoice);
+        break;
+
+      case "customer.subscription.deleted":
+        await handleSubscriptionDeleted(
+          event.data.object as Stripe.Subscription
+        );
+        break;
+
       default:
-        // Log unhandled event types for debugging, but return 200
         console.log(`Unhandled webhook event type: ${event.type}`);
     }
   } catch (err) {
-    // Log the error but do NOT propagate — webhook handlers must never return 5xx
     logServerError(`Error handling Stripe webhook ${event.type}`, {
       path: c.req.path,
       method: c.req.method,
@@ -247,7 +247,6 @@ stripeRoutes.post("/webhooks", async (c) => {
     });
   }
 
-  // Mark as processed only after successful dispatch attempt
   processedEventIds.add(event.id);
 
   return c.json({ received: true });
@@ -267,7 +266,6 @@ async function handlePaymentIntentSucceeded(
     return;
   }
 
-  // Update donation status
   const donation = await prisma.donation.update({
     where: { id: donationId },
     data: {
@@ -276,7 +274,6 @@ async function handlePaymentIntentSucceeded(
     },
   });
 
-  // Update donor aggregates
   await prisma.donor.update({
     where: { id: donation.donorId },
     data: {
@@ -287,7 +284,6 @@ async function handlePaymentIntentSucceeded(
     },
   });
 
-  // Update campaign aggregates (cached totals)
   await prisma.campaign.update({
     where: { id: donation.campaignId },
     data: {
@@ -296,102 +292,153 @@ async function handlePaymentIntentSucceeded(
     },
   });
 
-  // Send donation receipt email
   await sendReceiptEmail(donationId, donation.orgId);
 }
 
 /**
- * Sends a donation receipt email for the given donation.
- * Generates a receipt number, updates the donation record, and emails the donor.
- * Errors are logged but never thrown — we never fail a webhook due to email issues.
+ * Handle invoice.paid — fires for every successful subscription billing cycle.
+ * Creates a new Donation record for the cycle (after the first one).
  */
-async function sendReceiptEmail(
-  donationId: string,
-  orgId: string
-): Promise<void> {
-  try {
-    // Fetch full donation with related data
-    const donation = await prisma.donation.findUnique({
-      where: { id: donationId },
-      include: {
-        donor: true,
-        campaign: true,
-        org: true,
-      },
-    });
+async function handleInvoicePaid(invoice: Stripe.Invoice) {
+  const subscriptionId =
+    typeof invoice.subscription === "string"
+      ? invoice.subscription
+      : invoice.subscription?.id;
 
-    if (!donation) {
-      logServerError(`sendReceiptEmail: donation ${donationId} not found`, {
-        donationId,
-      });
-      return;
-    }
-
-    // Generate receipt number if not already set
-    let receiptNumber = donation.receiptNumber;
-    if (!receiptNumber) {
-      receiptNumber = await generateReceiptNumber(orgId, donation.createdAt);
-      await prisma.donation.update({
-        where: { id: donationId },
-        data: { receiptNumber },
-      });
-    }
-
-    // Build receipt template data
-    const receiptData = {
-      orgName: donation.org.name,
-      orgEin: donation.org.ein,
-      donorFirstName: donation.donor.firstName,
-      donorLastName: donation.donor.lastName,
-      donorEmail: donation.donor.email,
-      amountCents: donation.amountCents,
-      currency: donation.currency,
-      donationDate: donation.createdAt,
-      receiptNumber,
-      campaignName: donation.campaign.title,
-      dedicationType: donation.dedicationType,
-      dedicationName: donation.dedicationName,
-    };
-
-    const html = buildDonationReceiptHtml(receiptData);
-    const text = buildDonationReceiptText(receiptData);
-
-    // Send via Resend
-    const resend = getResend();
-    const fromEmail = getFromEmail();
-
-    const { error } = await resend.emails.send({
-      from: `${donation.org.name} via Give <${fromEmail}>`,
-      to: donation.donor.email,
-      subject: `Your donation receipt from ${donation.org.name} — ${receiptNumber}`,
-      html,
-      text,
-    });
-
-    if (error) {
-      logServerError(`Failed to send receipt email for donation ${donationId}`, {
-        donationId,
-        error,
-      });
-      return;
-    }
-
-    // Mark receipt as sent
-    await prisma.donation.update({
-      where: { id: donationId },
-      data: { receiptSentAt: new Date() },
-    });
-
-    console.log(
-      `Receipt email sent for donation ${donationId} to ${donation.donor.email} (receipt: ${receiptNumber})`
-    );
-  } catch (err) {
-    // Never propagate — a failed email must not fail the webhook
-    logServerError(
-      `Unexpected error sending receipt email for donation ${donationId}`,
-      { donationId, error: err }
-    );
+  if (!subscriptionId) {
+    console.warn("invoice.paid without subscriptionId:", invoice.id);
+    return;
   }
+
+  // Find the original "seed" donation for this subscription
+  const seedDonation = await prisma.donation.findFirst({
+    where: { stripeSubscriptionId: subscriptionId },
+    orderBy: { createdAt: "asc" },
+    include: { org: true },
+  });
+
+  if (!seedDonation) {
+    console.warn(
+      "invoice.paid: no donation found for subscription",
+      subscriptionId
+    );
+    return;
+  }
+
+  // If this is the first invoice (billing cycle 1), just mark the seed donation SUCCEEDED
+  const existingSucceeded = await prisma.donation.count({
+    where: { stripeSubscriptionId: subscriptionId, status: "SUCCEEDED" },
+  });
+
+  if (existingSucceeded === 0) {
+    // First payment — update the seed donation
+    const updated = await prisma.donation.update({
+      where: { id: seedDonation.id },
+      data: { status: "SUCCEEDED" },
+    });
+
+    await updateDonorAndCampaignAggregates(updated);
+    await sendReceiptEmail(updated.id, updated.orgId);
+    return;
+  }
+
+  // Subsequent billing cycles — create a new Donation record
+  const newDonation = await prisma.donation.create({
+    data: {
+      amountCents: seedDonation.amountCents,
+      currency: seedDonation.currency,
+      status: "SUCCEEDED",
+      frequency: seedDonation.frequency,
+      paymentMethod: seedDonation.paymentMethod,
+      processingFeeCents: seedDonation.processingFeeCents,
+      platformFeeCents: seedDonation.platformFeeCents,
+      netAmountCents: seedDonation.netAmountCents,
+      coverFees: seedDonation.coverFees,
+      totalChargedCents: seedDonation.totalChargedCents,
+      stripeSubscriptionId: subscriptionId,
+      stripeCustomerId: seedDonation.stripeCustomerId,
+      donorId: seedDonation.donorId,
+      campaignId: seedDonation.campaignId,
+      orgId: seedDonation.orgId,
+    },
+  });
+
+  await updateDonorAndCampaignAggregates(newDonation);
+  await sendReceiptEmail(newDonation.id, newDonation.orgId);
+}
+
+/**
+ * Handle invoice.payment_failed — update donation status and notify donor.
+ * Stripe will retry automatically based on Smart Retries settings.
+ */
+async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
+  const subscriptionId =
+    typeof invoice.subscription === "string"
+      ? invoice.subscription
+      : invoice.subscription?.id;
+
+  if (!subscriptionId) {
+    console.warn("invoice.payment_failed without subscriptionId:", invoice.id);
+    return;
+  }
+
+  const donation = await prisma.donation.findFirst({
+    where: { stripeSubscriptionId: subscriptionId },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (!donation) {
+    console.warn(
+      "invoice.payment_failed: no donation found for subscription",
+      subscriptionId
+    );
+    return;
+  }
+
+  // Mark as failed (Stripe will retry — do not permanently cancel yet)
+  await prisma.donation.update({
+    where: { id: donation.id },
+    data: { status: "FAILED" },
+  });
+
+  // TODO: send failed payment notification email to donor via Resend
+  console.log(
+    `Recurring payment failed for subscription ${subscriptionId}. ` +
+      `Donor: ${donation.donorId}. Stripe will retry automatically.`
+  );
+}
+
+/**
+ * Handle customer.subscription.deleted — subscription was cancelled (by donor or after retry exhaustion).
+ */
+async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
+  const subscriptionId = subscription.id;
+
+  // Find all donations for this subscription and mark them
+  const donations = await prisma.donation.findMany({
+    where: { stripeSubscriptionId: subscriptionId },
+    include: { donor: { select: { email: true, firstName: true } } },
+  });
+
+  if (donations.length === 0) {
+    console.warn(
+      "customer.subscription.deleted: no donations found for subscription",
+      subscriptionId
+    );
+    return;
+  }
+
+  await prisma.donation.updateMany({
+    where: { stripeSubscriptionId: subscriptionId },
+    data: { status: "FAILED" },
+  });
+
+  const donor = donations[0]?.donor;
+  console.log(
+    `Subscription ${subscriptionId} cancelled for donor ${donor?.email ?? "unknown"}.`
+  );
+
+  // TODO: send subscription cancellation confirmation email via Resend
 }
 
 async function handlePaymentIntentFailed(
@@ -419,28 +466,21 @@ async function handlePaymentIntentFailed(
 async function handleAccountUpdated(account: Stripe.Account) {
   if (!account.id) return;
 
-  // Find the org with this Stripe account
   const org = await prisma.organization.findUnique({
     where: { stripeAccountId: account.id },
   });
 
   if (!org) {
-    console.warn(
-      "account.updated for unknown Stripe account:",
-      account.id
-    );
+    console.warn("account.updated for unknown Stripe account:", account.id);
     return;
   }
 
-  // Check if onboarding is complete
-  const isOnboarded =
-    account.charges_enabled && account.payouts_enabled;
+  const isOnboarded = account.charges_enabled && account.payouts_enabled;
 
   const updateData: Record<string, unknown> = {
     stripeOnboarded: isOnboarded,
   };
 
-  // Move org to ACTIVE once Stripe onboarding is complete
   if (isOnboarded && org.status === "ONBOARDING") {
     updateData.status = "ACTIVE";
   }
@@ -457,9 +497,115 @@ async function handleAccountUpdated(account: Stripe.Account) {
 
 // ─── Helpers ──────────────────────────────────────────────
 
-async function getFirstDonationDate(
-  donorId: string
-): Promise<Date> {
+async function updateDonorAndCampaignAggregates(donation: {
+  donorId: string;
+  campaignId: string;
+  amountCents: number;
+}) {
+  await Promise.all([
+    prisma.donor.update({
+      where: { id: donation.donorId },
+      data: {
+        totalGivenCents: { increment: donation.amountCents },
+        donationCount: { increment: 1 },
+        lastDonationAt: new Date(),
+        firstDonationAt: await getFirstDonationDate(donation.donorId),
+      },
+    }),
+    prisma.campaign.update({
+      where: { id: donation.campaignId },
+      data: {
+        raisedAmountCents: { increment: donation.amountCents },
+        donationCount: { increment: 1 },
+      },
+    }),
+  ]);
+}
+
+async function sendReceiptEmail(
+  donationId: string,
+  orgId: string
+): Promise<void> {
+  try {
+    const donation = await prisma.donation.findUnique({
+      where: { id: donationId },
+      include: {
+        donor: true,
+        campaign: true,
+        org: true,
+      },
+    });
+
+    if (!donation) {
+      logServerError(`sendReceiptEmail: donation ${donationId} not found`, {
+        donationId,
+      });
+      return;
+    }
+
+    let receiptNumber = donation.receiptNumber;
+    if (!receiptNumber) {
+      receiptNumber = await generateReceiptNumber(orgId, donation.createdAt);
+      await prisma.donation.update({
+        where: { id: donationId },
+        data: { receiptNumber },
+      });
+    }
+
+    const receiptData = {
+      orgName: donation.org.name,
+      orgEin: donation.org.ein,
+      donorFirstName: donation.donor.firstName,
+      donorLastName: donation.donor.lastName,
+      donorEmail: donation.donor.email,
+      amountCents: donation.amountCents,
+      currency: donation.currency,
+      donationDate: donation.createdAt,
+      receiptNumber,
+      campaignName: donation.campaign.title,
+      dedicationType: donation.dedicationType,
+      dedicationName: donation.dedicationName,
+    };
+
+    const html = buildDonationReceiptHtml(receiptData);
+    const text = buildDonationReceiptText(receiptData);
+
+    const resend = getResend();
+    const fromEmail = getFromEmail();
+
+    const { error } = await resend.emails.send({
+      from: `${donation.org.name} via Give <${fromEmail}>`,
+      to: donation.donor.email,
+      subject: `Your donation receipt from ${donation.org.name} — ${receiptNumber}`,
+      html,
+      text,
+    });
+
+    if (error) {
+      logServerError(`Failed to send receipt email for donation ${donationId}`, {
+        donationId,
+        error,
+      });
+      return;
+    }
+
+    await prisma.donation.update({
+      where: { id: donationId },
+      data: { receiptSentAt: new Date() },
+    });
+
+    console.log(
+      `Receipt email sent for donation ${donationId} to ${donation.donor.email} (receipt: ${receiptNumber})`
+    );
+  } catch (err) {
+    logServerError(
+      `Unexpected error sending receipt email for donation ${donationId}`,
+      { donationId, error: err }
+    );
+  }
+}
+
+async function getFirstDonationDate(donorId: string): Promise<Date> {
   const first = await prisma.donation.findFirst({
     where: { donorId, status: "SUCCEEDED" },
     orderBy: { createdAt: "asc" },

--- a/apps/web/src/app/dashboard/campaigns/[id]/page.tsx
+++ b/apps/web/src/app/dashboard/campaigns/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 import Link from "next/link";
 import { getCampaign, listDonations } from "@/lib/api";
-import type { Campaign, Donation } from "@/lib/api";
+import type { Campaign, DonationListItem } from "@/lib/api";
 import GoalThermometer from "@/components/GoalThermometer";
 import CampaignQRCode from "@/components/CampaignQRCode";
 
@@ -112,7 +112,7 @@ export default function CampaignDetailPage() {
   const id = params.id as string;
 
   const [campaign, setCampaign] = useState<Campaign | null>(null);
-  const [donations, setDonations] = useState<Donation[]>([]);
+  const [donations, setDonations] = useState<DonationListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -130,7 +130,7 @@ export default function CampaignDetailPage() {
         getCampaign(id),
         orgId
           ? listDonations(orgId, getToken, { campaignId: id, limit: 10 })
-          : Promise.resolve({ data: [] as Donation[], pagination: { page: 1, limit: 10, total: 0, totalPages: 0 } }),
+          : Promise.resolve({ data: [] as DonationListItem[], pagination: { page: 1, limit: 10, total: 0, totalPages: 0 } }),
       ]);
       setCampaign(campaignData);
       setDonations(donationRes.data);
@@ -298,10 +298,10 @@ export default function CampaignDetailPage() {
                   {donations.map((d) => (
                     <tr key={d.id} className="hover:bg-gray-50/50 transition-colors">
                       <td className="px-6 py-3 text-gray-900">
-                        {d.anonymous ? (
+                        {d.donor?.anonymous ? (
                           <span className="text-gray-400 italic">Anonymous</span>
                         ) : (
-                          d.donorName
+                          d.donor ? `${d.donor.firstName} ${d.donor.lastName}` : 'Unknown'
                         )}
                       </td>
                       <td className="px-6 py-3 text-right font-medium text-gray-900">

--- a/apps/web/src/app/dashboard/donors/page.tsx
+++ b/apps/web/src/app/dashboard/donors/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useAuth } from "@clerk/nextjs";
-import { listDonors } from "@/lib/api";
-import type { Donor } from "@/lib/api";
+import Link from "next/link";
+import { listDonors, exportDonorsCsvUrl } from "@/lib/api";
+import type { Donor, DonorListMeta } from "@/lib/api";
 import { useCurrentOrg } from "@/hooks/useCurrentOrg";
 
-// ─── Helpers ──────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────
 
 function formatCurrency(cents: number): string {
   return new Intl.NumberFormat("en-US", {
@@ -26,9 +27,52 @@ function formatDate(iso: string | null): string {
   });
 }
 
-// ─── Skeleton ─────────────────────────────────────────────
+// ── Types ─────────────────────────────────────────────────
 
-function DonorRowSkeleton() {
+type SortField = "totalGivenCents" | "lastDonationAt" | "donationCount" | "firstDonationAt";
+type SortOrder = "asc" | "desc";
+type FrequencyFilter = "" | "one_time" | "recurring";
+
+// ── Sort header ───────────────────────────────────────────
+
+interface SortHeaderProps {
+  label: string;
+  field: SortField;
+  currentSort: SortField;
+  currentOrder: SortOrder;
+  onSort: (field: SortField) => void;
+  align?: "left" | "right";
+}
+
+function SortHeader({
+  label,
+  field,
+  currentSort,
+  currentOrder,
+  onSort,
+  align = "left",
+}: SortHeaderProps): React.ReactElement {
+  const active = currentSort === field;
+  return (
+    <th
+      className={`py-3 px-4 font-medium text-gray-500 cursor-pointer select-none hover:text-gray-700 transition-colors ${
+        align === "right" ? "text-right" : "text-left"
+      }`}
+      onClick={() => onSort(field)}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        <span className={`text-xs ${active ? "text-give-primary" : "text-gray-300"}`}>
+          {active ? (currentOrder === "desc" ? "↓" : "↑") : "↕"}
+        </span>
+      </span>
+    </th>
+  );
+}
+
+// ── Skeleton ──────────────────────────────────────────────
+
+function DonorRowSkeleton(): React.ReactElement {
   return (
     <tr className="animate-pulse border-b border-gray-50 last:border-0">
       <td className="py-4 px-6">
@@ -37,53 +81,106 @@ function DonorRowSkeleton() {
           <div className="h-4 bg-gray-100 rounded w-32" />
         </div>
       </td>
-      <td className="py-4 px-4"><div className="h-4 bg-gray-100 rounded w-40" /></td>
-      <td className="py-4 px-4 text-right"><div className="h-4 bg-gray-100 rounded w-16 ml-auto" /></td>
-      <td className="py-4 px-4 text-right"><div className="h-4 bg-gray-100 rounded w-8 ml-auto" /></td>
-      <td className="py-4 px-4"><div className="h-4 bg-gray-100 rounded w-24" /></td>
-      <td className="py-4 px-4"><div className="h-4 bg-gray-100 rounded w-24" /></td>
-      <td className="py-4 px-6"><div className="h-5 bg-gray-100 rounded-full w-20" /></td>
+      <td className="py-4 px-4">
+        <div className="h-4 bg-gray-100 rounded w-40" />
+      </td>
+      <td className="py-4 px-4 text-right">
+        <div className="h-4 bg-gray-100 rounded w-16 ml-auto" />
+      </td>
+      <td className="py-4 px-4 text-right">
+        <div className="h-4 bg-gray-100 rounded w-8 ml-auto" />
+      </td>
+      <td className="py-4 px-4">
+        <div className="h-4 bg-gray-100 rounded w-24" />
+      </td>
+      <td className="py-4 px-4">
+        <div className="h-4 bg-gray-100 rounded w-24" />
+      </td>
+      <td className="py-4 px-6">
+        <div className="h-5 bg-gray-100 rounded-full w-20" />
+      </td>
     </tr>
   );
 }
 
-// ─── Page Component ───────────────────────────────────────
+// ── Page ──────────────────────────────────────────────────
 
-export default function DonorsPage() {
+export default function DonorsPage(): React.ReactElement {
   const { orgId, loading: orgLoading, error: orgError } = useCurrentOrg();
   const { getToken } = useAuth();
+
   const [donors, setDonors] = useState<Donor[]>([]);
-  const [donorsLoading, setDonorsLoading] = useState(false);
-  const [donorsError, setDonorsError] = useState<string | null>(null);
+  const [meta, setMeta] = useState<DonorListMeta | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [sortBy, setSortBy] = useState<SortField>("lastDonationAt");
+  const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+  const [frequency, setFrequency] = useState<FrequencyFilter>("");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search), 350);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedSearch, sortBy, sortOrder, frequency, startDate, endDate]);
+
+  const fetchDonors = useCallback(async (): Promise<void> => {
     if (!orgId) return;
-    setDonorsLoading(true);
-    setDonorsError(null);
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await listDonors(orgId, getToken, {
+        page,
+        limit: 20,
+        search: debouncedSearch || undefined,
+        sortBy,
+        sortOrder,
+        frequency: frequency || undefined,
+        startDate: startDate ? new Date(startDate).toISOString() : undefined,
+        endDate: endDate ? new Date(endDate).toISOString() : undefined,
+      });
+      setDonors(result.data);
+      setMeta(result.meta);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load donors");
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, getToken, page, debouncedSearch, sortBy, sortOrder, frequency, startDate, endDate]);
 
-    listDonors(orgId, getToken)
-      .then((data) => setDonors(data))
-      .catch((err: unknown) => {
-        setDonorsError(err instanceof Error ? err.message : "Failed to load donors");
-      })
-      .finally(() => setDonorsLoading(false));
-  }, [orgId]);
+  useEffect(() => {
+    void fetchDonors();
+  }, [fetchDonors]);
 
-  const loading = orgLoading || donorsLoading;
+  function handleSort(field: SortField): void {
+    if (sortBy === field) {
+      setSortOrder((o) => (o === "desc" ? "asc" : "desc"));
+    } else {
+      setSortBy(field);
+      setSortOrder("desc");
+    }
+  }
 
-  const filtered = donors.filter((d) => {
-    const q = search.toLowerCase();
-    return (
-      d.firstName.toLowerCase().includes(q) ||
-      d.lastName.toLowerCase().includes(q) ||
-      d.email.toLowerCase().includes(q) ||
-      d.tags.some((t) => t.toLowerCase().includes(q))
-    );
-  });
+  function handleExportCsv(): void {
+    if (!orgId) return;
+    const url = exportDonorsCsvUrl(orgId, {
+      search: debouncedSearch || undefined,
+      frequency: frequency || undefined,
+      startDate: startDate ? new Date(startDate).toISOString() : undefined,
+      endDate: endDate ? new Date(endDate).toISOString() : undefined,
+    });
+    window.open(url, "_blank");
+  }
 
-  const hasNoDonors = !loading && donors.length === 0 && !donorsError;
-  const hasNoResults = !loading && donors.length > 0 && filtered.length === 0;
+  const isLoading = orgLoading || loading;
 
   if (orgError) {
     return (
@@ -95,88 +192,188 @@ export default function DonorsPage() {
 
   return (
     <div className="space-y-6">
-      {/* ── Page Header ─────────────────────────────── */}
+      {/* ── Header ─────────────────────────────────────── */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Donors</h1>
           <p className="mt-1 text-sm text-gray-500">
-            {loading
+            {isLoading
               ? "Loading donors\u2026"
-              : `${donors.length} donor${donors.length === 1 ? "" : "s"} in your organization.`}
+              : meta
+              ? `${meta.total.toLocaleString()} donor${meta.total === 1 ? "" : "s"}`
+              : ""}
           </p>
         </div>
-        <div className="relative w-full sm:w-80">
+        <button
+          onClick={handleExportCsv}
+          disabled={!orgId}
+          className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg border border-gray-200 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 transition-colors"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
+          </svg>
+          Export CSV
+        </button>
+      </div>
+
+      {/* ── Filters ────────────────────────────────────── */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1 min-w-0">
           <svg
             className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+            />
           </svg>
           <input
             type="text"
-            placeholder="Search by name, email, or tag..."
+            placeholder="Search by name or email\u2026"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             className="w-full pl-10 pr-4 py-2.5 rounded-lg border border-gray-200 text-sm focus:outline-none focus:border-give-primary focus:ring-2 focus:ring-give-primary/20 transition-all"
           />
         </div>
+        <select
+          value={frequency}
+          onChange={(e) => setFrequency(e.target.value as FrequencyFilter)}
+          className="px-3 py-2.5 rounded-lg border border-gray-200 text-sm text-gray-700 focus:outline-none focus:border-give-primary bg-white transition-all"
+        >
+          <option value="">All donors</option>
+          <option value="recurring">Recurring</option>
+          <option value="one_time">One-time</option>
+        </select>
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          title="From date"
+          className="px-3 py-2.5 rounded-lg border border-gray-200 text-sm text-gray-700 focus:outline-none focus:border-give-primary bg-white transition-all"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          title="To date"
+          className="px-3 py-2.5 rounded-lg border border-gray-200 text-sm text-gray-700 focus:outline-none focus:border-give-primary bg-white transition-all"
+        />
       </div>
 
-      {/* ── Error ────────────────────────────────────── */}
-      {donorsError && (
+      {/* ── Error ──────────────────────────────────────── */}
+      {error && (
         <div className="rounded-xl border border-red-100 bg-red-50 p-4 text-sm text-red-600">
-          Error loading donors: {donorsError}
+          {error}
         </div>
       )}
 
-      {/* ── Empty State ──────────────────────────────── */}
-      {hasNoDonors && (
-        <div className="bg-white rounded-xl border border-gray-100 px-6 py-16 text-center">
-          <p className="text-gray-900 font-semibold mb-1">No donors yet</p>
-          <p className="text-gray-500 text-sm">Share your campaign to start receiving donations.</p>
-        </div>
-      )}
-
-      {/* ── Table ────────────────────────────────────── */}
-      {(loading || donors.length > 0) && !donorsError && (
+      {/* ── Table ──────────────────────────────────────── */}
+      {!error && (
         <div className="bg-white rounded-xl border border-gray-100 overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-100 bg-gray-50/50">
-                  <th className="text-left py-3 px-6 font-medium text-gray-500">Donor</th>
-                  <th className="text-left py-3 px-4 font-medium text-gray-500">Email</th>
-                  <th className="text-right py-3 px-4 font-medium text-gray-500">Total Given</th>
-                  <th className="text-right py-3 px-4 font-medium text-gray-500">Donations</th>
-                  <th className="text-left py-3 px-4 font-medium text-gray-500">First Gift</th>
-                  <th className="text-left py-3 px-4 font-medium text-gray-500">Last Gift</th>
-                  <th className="text-left py-3 px-6 font-medium text-gray-500">Tags</th>
+                  <th className="text-left py-3 px-6 font-medium text-gray-500">
+                    Donor
+                  </th>
+                  <th className="text-left py-3 px-4 font-medium text-gray-500">
+                    Email
+                  </th>
+                  <SortHeader
+                    label="Total Given"
+                    field="totalGivenCents"
+                    currentSort={sortBy}
+                    currentOrder={sortOrder}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="Gifts"
+                    field="donationCount"
+                    currentSort={sortBy}
+                    currentOrder={sortOrder}
+                    onSort={handleSort}
+                    align="right"
+                  />
+                  <SortHeader
+                    label="First Gift"
+                    field="firstDonationAt"
+                    currentSort={sortBy}
+                    currentOrder={sortOrder}
+                    onSort={handleSort}
+                  />
+                  <SortHeader
+                    label="Last Gift"
+                    field="lastDonationAt"
+                    currentSort={sortBy}
+                    currentOrder={sortOrder}
+                    onSort={handleSort}
+                  />
+                  <th className="text-left py-3 px-6 font-medium text-gray-500">
+                    Tags
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-50">
-                {loading
-                  ? Array.from({ length: 5 }).map((_, i) => <DonorRowSkeleton key={i} />)
-                  : filtered.map((d) => (
-                      <tr key={d.id} className="hover:bg-gray-50/50 transition-colors">
+                {isLoading
+                  ? Array.from({ length: 6 }).map((_, i) => (
+                      <DonorRowSkeleton key={i} />
+                    ))
+                  : donors.map((d) => (
+                      <tr
+                        key={d.id}
+                        className="hover:bg-gray-50/60 transition-colors group cursor-pointer"
+                      >
                         <td className="py-4 px-6">
-                          <div className="flex items-center gap-3">
+                          <Link
+                            href={`/dashboard/donors/${d.id}`}
+                            className="flex items-center gap-3"
+                          >
                             <div className="w-8 h-8 rounded-full bg-give-primary/10 flex items-center justify-center text-xs font-bold text-give-primary flex-shrink-0">
-                              {d.firstName.charAt(0)}{d.lastName.charAt(0)}
+                              {d.firstName.charAt(0)}
+                              {d.lastName.charAt(0)}
                             </div>
-                            <span className="font-medium text-gray-900">{d.firstName} {d.lastName}</span>
-                          </div>
+                            <span className="font-medium text-gray-900 group-hover:text-give-primary transition-colors">
+                              {d.firstName} {d.lastName}
+                            </span>
+                          </Link>
                         </td>
                         <td className="py-4 px-4 text-gray-500">{d.email}</td>
-                        <td className="py-4 px-4 text-right font-semibold text-gray-900">{formatCurrency(d.totalGivenCents)}</td>
-                        <td className="py-4 px-4 text-right text-gray-600">{d.donationCount}</td>
-                        <td className="py-4 px-4 text-gray-400">{formatDate(d.firstDonationAt)}</td>
-                        <td className="py-4 px-4 text-gray-400">{formatDate(d.lastDonationAt)}</td>
+                        <td className="py-4 px-4 text-right font-semibold text-gray-900">
+                          {formatCurrency(d.totalGivenCents)}
+                        </td>
+                        <td className="py-4 px-4 text-right text-gray-600">
+                          {d.donationCount}
+                        </td>
+                        <td className="py-4 px-4 text-gray-400">
+                          {formatDate(d.firstDonationAt)}
+                        </td>
+                        <td className="py-4 px-4 text-gray-400">
+                          {formatDate(d.lastDonationAt)}
+                        </td>
                         <td className="py-4 px-6">
                           <div className="flex flex-wrap gap-1">
                             {d.tags.map((tag) => (
-                              <span key={tag} className="inline-flex text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600">
+                              <span
+                                key={tag}
+                                className="inline-flex text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600"
+                              >
                                 {tag}
                               </span>
                             ))}
@@ -184,16 +381,51 @@ export default function DonorsPage() {
                         </td>
                       </tr>
                     ))}
-                {hasNoResults && (
+                {!isLoading && donors.length === 0 && (
                   <tr>
-                    <td colSpan={7} className="py-12 text-center text-gray-400">
-                      No donors match your search.
+                    <td colSpan={7} className="py-16 text-center">
+                      <p className="text-gray-500 text-sm font-medium">
+                        No donors found
+                      </p>
+                      <p className="text-gray-400 text-xs mt-1">
+                        Try adjusting your filters
+                      </p>
                     </td>
                   </tr>
                 )}
               </tbody>
             </table>
           </div>
+
+          {/* Pagination */}
+          {meta && meta.totalPages > 1 && (
+            <div className="flex items-center justify-between px-6 py-3 border-t border-gray-100 bg-gray-50/30">
+              <p className="text-sm text-gray-500">
+                {(meta.page - 1) * meta.limit + 1}&ndash;
+                {Math.min(meta.page * meta.limit, meta.total)} of{" "}
+                {meta.total.toLocaleString()}
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                  className="px-3 py-1.5 rounded-lg text-sm border border-gray-200 text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  Previous
+                </button>
+                <span className="text-sm text-gray-500">
+                  {meta.page} / {meta.totalPages}
+                </span>
+                <button
+                  disabled={page >= meta.totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                  className="px-3 py-1.5 rounded-lg text-sm border border-gray-200 text-gray-600 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/app/manage/[donorToken]/page.tsx
+++ b/apps/web/src/app/manage/[donorToken]/page.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+
+interface Subscription {
+  donationId: string;
+  subscriptionId: string | null;
+  amountCents: number;
+  frequency: string;
+  status: string;
+  campaign: { id: string; title: string; slug: string };
+  org: { id: string; name: string; logoUrl: string | null };
+  createdAt: string;
+}
+
+interface ManageData {
+  donor: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+  };
+  subscriptions: Subscription[];
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8787";
+
+const FREQUENCY_LABELS: Record<string, string> = {
+  MONTHLY: "Monthly",
+  QUARTERLY: "Quarterly",
+  ANNUAL: "Annual",
+  ONE_TIME: "One-time",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  SUCCEEDED: "bg-green-100 text-green-800",
+  PROCESSING: "bg-blue-100 text-blue-800",
+  FAILED: "bg-red-100 text-red-800",
+  PENDING: "bg-yellow-100 text-yellow-800",
+};
+
+function formatCents(cents: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100);
+}
+
+export default function ManagePage() {
+  const params = useParams();
+  const token = params.donorToken as string;
+
+  const [data, setData] = useState<ManageData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [cancelConfirm, setCancelConfirm] = useState<string | null>(null);
+  const [updateAmount, setUpdateAmount] = useState<{
+    subscriptionId: string;
+    value: string;
+  } | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/manage/${token}`)
+      .then((r) => r.json())
+      .then((d: ManageData & { error?: string }) => {
+        if (d.error) {
+          setError(d.error);
+        } else {
+          setData(d);
+        }
+      })
+      .catch(() => setError("Failed to load subscription data."))
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  async function openPortal() {
+    setActionLoading("portal");
+    try {
+      const res = await fetch(`${API_URL}/api/manage/${token}/portal`, {
+        method: "POST",
+      });
+      const d = await res.json();
+      if (d.portalUrl) {
+        window.location.href = d.portalUrl;
+      } else {
+        setError(d.error ?? "Failed to open billing portal.");
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  async function cancelSubscription(subscriptionId: string) {
+    setActionLoading(`cancel-${subscriptionId}`);
+    try {
+      const res = await fetch(`${API_URL}/api/manage/${token}/cancel`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ subscriptionId }),
+      });
+      const d = await res.json();
+      if (d.success) {
+        setSuccessMsg("Your recurring donation has been cancelled.");
+        setData((prev) =>
+          prev
+            ? {
+                ...prev,
+                subscriptions: prev.subscriptions.map((s) =>
+                  s.subscriptionId === subscriptionId
+                    ? { ...s, status: "FAILED" }
+                    : s
+                ),
+              }
+            : prev
+        );
+      } else {
+        setError(d.error ?? "Failed to cancel subscription.");
+      }
+    } finally {
+      setActionLoading(null);
+      setCancelConfirm(null);
+    }
+  }
+
+  async function updateDonationAmount(
+    subscriptionId: string,
+    amountStr: string
+  ) {
+    const newAmountCents = Math.round(parseFloat(amountStr) * 100);
+    if (isNaN(newAmountCents) || newAmountCents < 100) {
+      setError("Please enter a valid amount (minimum $1.00).");
+      return;
+    }
+
+    setActionLoading(`update-${subscriptionId}`);
+    try {
+      const res = await fetch(`${API_URL}/api/manage/${token}/update-amount`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ subscriptionId, newAmountCents }),
+      });
+      const d = await res.json();
+      if (d.success) {
+        setSuccessMsg(`Donation amount updated to ${formatCents(newAmountCents)}.`);
+        setData((prev) =>
+          prev
+            ? {
+                ...prev,
+                subscriptions: prev.subscriptions.map((s) =>
+                  s.subscriptionId === subscriptionId
+                    ? { ...s, amountCents: newAmountCents }
+                    : s
+                ),
+              }
+            : prev
+        );
+        setUpdateAmount(null);
+      } else {
+        setError(d.error ?? "Failed to update amount.");
+      }
+    } finally {
+      setActionLoading(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-gray-500 text-sm animate-pulse">Loading your donations…</div>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center px-6">
+        <div className="text-center max-w-sm">
+          <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <span className="text-red-600 text-xl">!</span>
+          </div>
+          <h1 className="text-xl font-semibold text-gray-900 mb-2">
+            Unable to load
+          </h1>
+          <p className="text-gray-500 text-sm mb-6">{error}</p>
+          <p className="text-xs text-gray-400">
+            This link may be invalid or expired. Please check your receipt email
+            for the correct link.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white border-b border-gray-100">
+        <div className="max-w-2xl mx-auto px-6 py-4 flex items-center justify-between">
+          <Link href="/" className="text-xl font-bold text-give-primary tracking-tight">
+            Give
+          </Link>
+          <span className="text-sm text-gray-500">Manage your donations</span>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-6 py-10">
+        {data && (
+          <>
+            <div className="mb-8">
+              <h1 className="text-2xl font-bold text-gray-900">
+                Hi {data.donor.firstName} 👋
+              </h1>
+              <p className="text-gray-500 mt-1 text-sm">
+                Manage your recurring donations below, or{" "}
+                <button
+                  onClick={openPortal}
+                  disabled={actionLoading === "portal"}
+                  className="text-give-primary underline hover:no-underline disabled:opacity-50"
+                >
+                  {actionLoading === "portal"
+                    ? "Opening portal…"
+                    : "open the full billing portal"}
+                </button>{" "}
+                to update your payment method.
+              </p>
+            </div>
+
+            {successMsg && (
+              <div className="mb-6 bg-green-50 border border-green-200 rounded-lg px-4 py-3 text-green-800 text-sm flex items-center gap-2">
+                <span>✓</span>
+                <span>{successMsg}</span>
+                <button
+                  onClick={() => setSuccessMsg(null)}
+                  className="ml-auto text-green-600 hover:text-green-800"
+                >
+                  ×
+                </button>
+              </div>
+            )}
+
+            {error && (
+              <div className="mb-6 bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-red-800 text-sm flex items-center gap-2">
+                <span>!</span>
+                <span>{error}</span>
+                <button
+                  onClick={() => setError(null)}
+                  className="ml-auto text-red-600 hover:text-red-800"
+                >
+                  ×
+                </button>
+              </div>
+            )}
+
+            {data.subscriptions.length === 0 ? (
+              <div className="bg-white rounded-xl border border-gray-200 p-8 text-center">
+                <p className="text-gray-500 text-sm">
+                  No active recurring donations found.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {data.subscriptions.map((sub) => {
+                  const isCancelled = sub.status === "FAILED";
+                  return (
+                    <div
+                      key={sub.donationId}
+                      className="bg-white rounded-xl border border-gray-200 p-6"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <p className="font-semibold text-gray-900">
+                            {formatCents(sub.amountCents)}{" "}
+                            <span className="font-normal text-gray-500">
+                              / {FREQUENCY_LABELS[sub.frequency] ?? sub.frequency}
+                            </span>
+                          </p>
+                          <p className="text-sm text-gray-500 mt-0.5">
+                            {sub.campaign.title} · {sub.org.name}
+                          </p>
+                          <p className="text-xs text-gray-400 mt-0.5">
+                            Started{" "}
+                            {new Date(sub.createdAt).toLocaleDateString("en-US", {
+                              month: "long",
+                              year: "numeric",
+                            })}
+                          </p>
+                        </div>
+                        <span
+                          className={`shrink-0 text-xs font-medium px-2.5 py-1 rounded-full ${
+                            STATUS_COLORS[sub.status] ?? "bg-gray-100 text-gray-700"
+                          }`}
+                        >
+                          {isCancelled ? "Cancelled" : sub.status.charAt(0) + sub.status.slice(1).toLowerCase()}
+                        </span>
+                      </div>
+
+                      {!isCancelled && sub.subscriptionId && (
+                        <div className="mt-4 pt-4 border-t border-gray-100 flex flex-wrap gap-3">
+                          {/* Update amount */}
+                          {updateAmount?.subscriptionId === sub.subscriptionId ? (
+                            <div className="flex items-center gap-2 w-full">
+                              <span className="text-gray-500 text-sm">$</span>
+                              <input
+                                type="number"
+                                min="1"
+                                step="0.01"
+                                className="border border-gray-300 rounded-md px-3 py-1.5 text-sm w-28 focus:outline-none focus:ring-2 focus:ring-give-primary"
+                                value={updateAmount.value}
+                                onChange={(e) =>
+                                  setUpdateAmount({
+                                    subscriptionId: sub.subscriptionId!,
+                                    value: e.target.value,
+                                  })
+                                }
+                                placeholder={(sub.amountCents / 100).toFixed(2)}
+                              />
+                              <button
+                                disabled={
+                                  actionLoading === `update-${sub.subscriptionId}`
+                                }
+                                onClick={() =>
+                                  updateDonationAmount(
+                                    sub.subscriptionId!,
+                                    updateAmount.value
+                                  )
+                                }
+                                className="px-3 py-1.5 bg-give-primary text-white rounded-md text-sm font-medium disabled:opacity-50 hover:bg-give-primary/90"
+                              >
+                                {actionLoading === `update-${sub.subscriptionId}`
+                                  ? "Saving…"
+                                  : "Save"}
+                              </button>
+                              <button
+                                onClick={() => setUpdateAmount(null)}
+                                className="px-3 py-1.5 text-gray-500 rounded-md text-sm hover:text-gray-700"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              onClick={() =>
+                                setUpdateAmount({
+                                  subscriptionId: sub.subscriptionId!,
+                                  value: (sub.amountCents / 100).toFixed(2),
+                                })
+                              }
+                              className="text-sm text-give-primary font-medium hover:underline"
+                            >
+                              Change amount
+                            </button>
+                          )}
+
+                          {/* Cancel */}
+                          {cancelConfirm === sub.subscriptionId ? (
+                            <div className="flex items-center gap-2 w-full">
+                              <span className="text-sm text-gray-700">
+                                Cancel your recurring donation?
+                              </span>
+                              <button
+                                disabled={
+                                  actionLoading === `cancel-${sub.subscriptionId}`
+                                }
+                                onClick={() =>
+                                  cancelSubscription(sub.subscriptionId!)
+                                }
+                                className="px-3 py-1.5 bg-red-600 text-white rounded-md text-sm font-medium disabled:opacity-50 hover:bg-red-700"
+                              >
+                                {actionLoading === `cancel-${sub.subscriptionId}`
+                                  ? "Cancelling…"
+                                  : "Yes, cancel"}
+                              </button>
+                              <button
+                                onClick={() => setCancelConfirm(null)}
+                                className="px-3 py-1.5 text-gray-500 rounded-md text-sm hover:text-gray-700"
+                              >
+                                Keep it
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              onClick={() =>
+                                setCancelConfirm(sub.subscriptionId!)
+                              }
+                              className="text-sm text-red-500 font-medium hover:underline"
+                            >
+                              Cancel donation
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -227,17 +227,64 @@ export function getDonation(id: string): Promise<DonationDetail> {
   return request<DonationDetail>(`/api/donations/${id}`);
 }
 
+export interface ListDonationsFilters {
+  campaignId?: string;
+  status?: string;
+  startDate?: string;
+  endDate?: string;
+  search?: string;
+  sortBy?: "createdAt" | "amountCents" | "status";
+  sortOrder?: "asc" | "desc";
+  page?: number;
+  limit?: number;
+}
+
+export interface DonationListItem {
+  id: string;
+  amountCents: number;
+  totalChargedCents: number;
+  currency: string;
+  frequency: string;
+  status: string;
+  paymentMethod: string | null;
+  coverFees: boolean;
+  createdAt: string;
+  donor: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    anonymous: boolean;
+  } | null;
+  campaign: {
+    id: string;
+    title: string;
+    slug: string;
+  } | null;
+}
+
+export interface DonationListResponse {
+  data: DonationListItem[];
+  pagination: { page: number; limit: number; total: number; totalPages: number };
+}
+
 /** Protected — org dashboard lists donations */
 export function listDonations(
   orgId: string,
-  token: TokenGetter,
-  opts?: { campaignId?: string; limit?: number; page?: number }
-): Promise<{ data: Donation[]; pagination: { page: number; limit: number; total: number; totalPages: number } }> {
+  token?: TokenGetter,
+  filters?: ListDonationsFilters
+): Promise<DonationListResponse> {
   const params = new URLSearchParams({ orgId });
-  if (opts?.campaignId) params.set("campaignId", opts.campaignId);
-  if (opts?.limit) params.set("limit", String(opts.limit));
-  if (opts?.page) params.set("page", String(opts.page));
-  return request<{ data: Donation[]; pagination: { page: number; limit: number; total: number; totalPages: number } }>(`/api/donations?${params}`, { token });
+  if (filters?.campaignId) params.set("campaignId", filters.campaignId);
+  if (filters?.status) params.set("status", filters.status);
+  if (filters?.startDate) params.set("startDate", filters.startDate);
+  if (filters?.endDate) params.set("endDate", filters.endDate);
+  if (filters?.search) params.set("search", filters.search);
+  if (filters?.sortBy) params.set("sortBy", filters.sortBy);
+  if (filters?.sortOrder) params.set("sortOrder", filters.sortOrder);
+  if (filters?.limit) params.set("limit", String(filters.limit));
+  if (filters?.page) params.set("page", String(filters.page));
+  return request<DonationListResponse>(`/api/donations?${params}`, token ? { token } : undefined);
 }
 
 // ─── Donor ───────────────────────────────────────────────
@@ -256,14 +303,56 @@ export interface Donor {
   createdAt: string;
 }
 
+export interface DonorListMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
+export interface DonorListParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  sortBy?: "totalGivenCents" | "lastDonationAt" | "donationCount" | "firstDonationAt";
+  sortOrder?: "asc" | "desc";
+  frequency?: "one_time" | "recurring";
+  startDate?: string;
+  endDate?: string;
+  campaignId?: string;
+}
+
 /** Protected — org dashboard */
 export function listDonors(
   orgId: string,
-  token: TokenGetter
-): Promise<Donor[]> {
-  return request<{ data: Donor[] }>(`/api/orgs/${orgId}/donors`, { token }).then(
-    (r) => r.data
-  );
+  token: TokenGetter,
+  params?: DonorListParams
+): Promise<{ data: Donor[]; meta: DonorListMeta }> {
+  const qp = new URLSearchParams({ orgId });
+  if (params?.page) qp.set("page", String(params.page));
+  if (params?.limit) qp.set("limit", String(params.limit));
+  if (params?.search) qp.set("search", params.search);
+  if (params?.sortBy) qp.set("sortBy", params.sortBy);
+  if (params?.sortOrder) qp.set("sortOrder", params.sortOrder);
+  if (params?.frequency) qp.set("frequency", params.frequency);
+  if (params?.startDate) qp.set("startDate", params.startDate);
+  if (params?.endDate) qp.set("endDate", params.endDate);
+  if (params?.campaignId) qp.set("campaignId", params.campaignId);
+  return request<{ data: Donor[]; meta: DonorListMeta }>(`/api/donors?${qp}`, { token });
+}
+
+/** Returns the CSV export URL for donors matching the given filters */
+export function exportDonorsCsvUrl(
+  orgId: string,
+  params?: Omit<DonorListParams, "page" | "limit" | "sortBy" | "sortOrder">
+): string {
+  const qp = new URLSearchParams({ orgId });
+  if (params?.search) qp.set("search", params.search);
+  if (params?.frequency) qp.set("frequency", params.frequency);
+  if (params?.startDate) qp.set("startDate", params.startDate);
+  if (params?.endDate) qp.set("endDate", params.endDate);
+  if (params?.campaignId) qp.set("campaignId", params.campaignId);
+  return `${BASE_URL}/api/donors/export?${qp}`;
 }
 
 // ─── Organization Stats ──────────────────────────────────


### PR DESCRIPTION
Closes #45

## Changes

### API
- **`lib/stripe.ts`** — New helpers: `createStripeCustomer`, `createSubscription`, `cancelSubscription`, `updateSubscriptionAmount`, `createBillingPortalSession`, `computeApplicationFeePercent`
- **`lib/manage-token.ts`** — HMAC-SHA256 signed donor management tokens (no DB storage needed)
- **`routes/donations.ts`** — Branches on frequency: recurring creates Stripe Subscription + Customer; one-time keeps existing PaymentIntent flow. Returns `manageUrl` in response.
- **`routes/manage.ts`** — Token-authenticated donor self-service API:
  - `GET /api/manage/:token` — list donor subscriptions
  - `POST /api/manage/:token/portal` — create Stripe Billing Portal session
  - `POST /api/manage/:token/cancel` — cancel a subscription
  - `POST /api/manage/:token/update-amount` — change recurring amount
- **`routes/stripe.ts`** — New webhook handlers:
  - `invoice.paid` — marks first payment SUCCEEDED, creates new Donation records for subsequent cycles
  - `invoice.payment_failed` — marks donation FAILED, logs for Stripe Smart Retry
  - `customer.subscription.deleted` — marks all related donations FAILED
- **`routes/donations.ts`** — New `GET /donations/recurring/metrics` endpoint: active recurring donors, MRR (normalized), churn in last 30 days

### Web
- **`app/manage/[donorToken]/page.tsx`** — Donor self-service page with:
  - View all active subscriptions
  - Change donation amount inline
  - Cancel with confirmation step
  - Link to full Stripe Billing Portal (for payment method updates)

## Notes
- Quarterly is implemented as 3-month interval (`interval_count: 3`) since Stripe has no native quarterly
- Email integration (Resend) left as TODO comments — management URL is returned in API response and will be added to receipt email when Resend is wired up
- Pre-existing TS error in `dashboard/campaigns/[id]/page.tsx` — not introduced by this PR